### PR TITLE
Potential fix for code scanning alert no. 1: Disabled Spring CSRF protection

### DIFF
--- a/backend/src/main/java/com/aaron212/onlinelibrarymanagement/backend/config/SecurityConfig.java
+++ b/backend/src/main/java/com/aaron212/onlinelibrarymanagement/backend/config/SecurityConfig.java
@@ -36,7 +36,7 @@ public class SecurityConfig {
                         .permitAll()
                         .requestMatchers("/auth/hello")
                         .authenticated())
-                .csrf(AbstractHttpConfigurer::disable)
+                .csrf((csrf) -> csrf.ignoringRequestMatchers("/auth/login", "/auth/register"))
                 .sessionManagement((session) -> session.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
                 .addFilterBefore(authFilter, UsernamePasswordAuthenticationFilter.class)
                 .build();


### PR DESCRIPTION
Potential fix for [https://github.com/Aaron-212/online-library-management/security/code-scanning/1](https://github.com/Aaron-212/online-library-management/security/code-scanning/1)

To fix the issue, CSRF protection should be enabled in the `SecurityFilterChain` configuration. This involves removing the `csrf(AbstractHttpConfigurer::disable)` line and ensuring that CSRF protection is properly configured. If certain endpoints (e.g., `/auth/login`, `/auth/register`) need to bypass CSRF protection for legitimate reasons, this can be achieved by customizing the CSRF configuration to exclude specific endpoints.

**Steps to implement the fix:**
1. Remove the `csrf(AbstractHttpConfigurer::disable)` line from the `filterChain` method.
2. Optionally, configure CSRF protection to exclude specific endpoints if necessary using `csrf((csrf) -> csrf.ignoringRequestMatchers(...))`.
3. Ensure that CSRF tokens are properly handled in the application, especially for state-changing requests.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
