### PR TITLE
Add CommentController on new branch

### DIFF
--- a/backend/src/main/java/com/aaron212/onlinelibrarymanagement/backend/controller/CommentController.java
+++ b/backend/src/main/java/com/aaron212/onlinelibrarymanagement/backend/controller/CommentController.java
@@ -1,0 +1,430 @@
+package com.aaron212.onlinelibrarymanagement.backend.controller;
+
+import com.aaron212.onlinelibrarymanagement.backend.dto.CommentCreateDto;
+import com.aaron212.onlinelibrarymanagement.backend.dto.CommentDto;
+import com.aaron212.onlinelibrarymanagement.backend.dto.CommentUpdateDto;
+import com.aaron212.onlinelibrarymanagement.backend.model.User;
+import com.aaron212.onlinelibrarymanagement.backend.repository.UserRepository;
+import com.aaron212.onlinelibrarymanagement.backend.service.CommentService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.Positive;
+import org.springdoc.core.annotations.ParameterObject;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.web.config.EnableSpringDataWebSupport;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.security.core.Authentication;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+
+import static org.springframework.data.web.config.EnableSpringDataWebSupport.PageSerializationMode.VIA_DTO;
+
+@RestController
+@RequestMapping("/api/v1/comments")
+@EnableSpringDataWebSupport(pageSerializationMode = VIA_DTO)
+@Tag(name = "Comments", description = "Comment management endpoints")
+public class CommentController {
+
+    private final CommentService commentService;
+    private final UserRepository userRepository;
+
+    public CommentController(CommentService commentService, UserRepository userRepository) {
+        this.commentService = commentService;
+        this.userRepository = userRepository;
+    }
+
+    @Operation(
+            summary = "Create a new comment",
+            description = "Creates a new comment for a book. Comments are initially pending and require approval.",
+            security = @SecurityRequirement(name = "Bearer Authentication"))
+    @ApiResponses(
+            value = {
+                @ApiResponse(
+                        responseCode = "201",
+                        description = "Comment created successfully",
+                        content = @Content(schema = @Schema(implementation = CommentDto.class))),
+                @ApiResponse(
+                        responseCode = "400",
+                        description = "Invalid comment data or user has already commented on this book",
+                        content = @Content(schema = @Schema(implementation = Map.class))),
+                @ApiResponse(
+                        responseCode = "404",
+                        description = "Book not found",
+                        content = @Content(schema = @Schema(implementation = Map.class))),
+                @ApiResponse(
+                        responseCode = "401",
+                        description = "User not authenticated",
+                        content = @Content(schema = @Schema(implementation = Map.class)))
+            })
+    @PostMapping
+    public ResponseEntity<?> createComment(@Valid @RequestBody CommentCreateDto commentCreateDto, Authentication authentication) {
+        if (authentication == null || !authentication.isAuthenticated()) {
+            return ResponseEntity.status(HttpStatus.UNAUTHORIZED).body(Map.of("error", "User not authenticated"));
+        }
+
+        try {
+            CommentDto createdComment = commentService.createComment(commentCreateDto, authentication.getName());
+            return ResponseEntity.status(HttpStatus.CREATED).body(createdComment);
+        } catch (RuntimeException e) {
+            if (e.getMessage().contains("not found")) {
+                return ResponseEntity.status(HttpStatus.NOT_FOUND).body(Map.of("error", e.getMessage()));
+            }
+            return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(Map.of("error", e.getMessage()));
+        }
+    }
+
+    @Operation(
+            summary = "Get comment by ID",
+            description = "Retrieves a specific comment by its ID")
+    @ApiResponses(
+            value = {
+                @ApiResponse(
+                        responseCode = "200",
+                        description = "Comment found",
+                        content = @Content(schema = @Schema(implementation = CommentDto.class))),
+                @ApiResponse(
+                        responseCode = "404",
+                        description = "Comment not found",
+                        content = @Content(schema = @Schema(implementation = Map.class)))
+            })
+    @GetMapping("/{id}")
+    public ResponseEntity<?> getCommentById(
+            @Parameter(description = "Comment ID", required = true, example = "1") @PathVariable @Positive Long id) {
+        try {
+            Optional<CommentDto> comment = commentService.getCommentById(id);
+            if (comment.isPresent()) {
+                return ResponseEntity.ok(comment.get());
+            } else {
+                return ResponseEntity.status(HttpStatus.NOT_FOUND).body(Map.of("error", "Comment not found"));
+            }
+        } catch (Exception e) {
+            return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).body(Map.of("error", "Failed to retrieve comment"));
+        }
+    }
+
+    @Operation(
+            summary = "Get published comments for a book",
+            description = "Retrieves all published comments for a specific book with pagination")
+    @ApiResponses(
+            value = {
+                @ApiResponse(
+                        responseCode = "200",
+                        description = "Comments retrieved successfully",
+                        content = @Content(schema = @Schema(implementation = Page.class))),
+                @ApiResponse(
+                        responseCode = "404",
+                        description = "Book not found",
+                        content = @Content(schema = @Schema(implementation = Map.class)))
+            })
+    @GetMapping("/book/{bookId}")
+    public ResponseEntity<?> getCommentsByBook(
+            @Parameter(description = "Book ID", required = true, example = "1") @PathVariable @Positive Long bookId,
+            @Parameter(description = "Pagination parameters") @ParameterObject Pageable pageable) {
+        try {
+            Page<CommentDto> comments = commentService.getPublishedCommentsByBook(bookId, pageable);
+            return ResponseEntity.ok(comments);
+        } catch (RuntimeException e) {
+            return ResponseEntity.status(HttpStatus.NOT_FOUND).body(Map.of("error", e.getMessage()));
+        }
+    }
+
+    @Operation(
+            summary = "Get comments by user",
+            description = "Retrieves all published comments by a specific user with pagination",
+            security = @SecurityRequirement(name = "Bearer Authentication"))
+    @ApiResponses(
+            value = {
+                @ApiResponse(
+                        responseCode = "200",
+                        description = "Comments retrieved successfully",
+                        content = @Content(schema = @Schema(implementation = Page.class))),
+                @ApiResponse(
+                        responseCode = "404",
+                        description = "User not found",
+                        content = @Content(schema = @Schema(implementation = Map.class))),
+                @ApiResponse(
+                        responseCode = "401",
+                        description = "User not authenticated",
+                        content = @Content(schema = @Schema(implementation = Map.class)))
+            })
+    @GetMapping("/user/{username}")
+    public ResponseEntity<?> getCommentsByUser(
+            @Parameter(description = "Username", required = true, example = "john_doe") @PathVariable String username,
+            @Parameter(description = "Pagination parameters") @ParameterObject Pageable pageable) {
+        try {
+            Page<CommentDto> comments = commentService.getCommentsByUser(username, pageable);
+            return ResponseEntity.ok(comments);
+        } catch (RuntimeException e) {
+            return ResponseEntity.status(HttpStatus.NOT_FOUND).body(Map.of("error", e.getMessage()));
+        }
+    }
+
+    @Operation(
+            summary = "Get current user's comments",
+            description = "Retrieves all published comments by the currently authenticated user with pagination",
+            security = @SecurityRequirement(name = "Bearer Authentication"))
+    @ApiResponses(
+            value = {
+                @ApiResponse(
+                        responseCode = "200",
+                        description = "Comments retrieved successfully",
+                        content = @Content(schema = @Schema(implementation = Page.class))),
+                @ApiResponse(
+                        responseCode = "401",
+                        description = "User not authenticated",
+                        content = @Content(schema = @Schema(implementation = Map.class)))
+            })
+    @GetMapping("/my-comments")
+    public ResponseEntity<?> getCurrentUserComments(
+            @Parameter(description = "Pagination parameters") @ParameterObject Pageable pageable,
+            Authentication authentication) {
+        if (authentication == null || !authentication.isAuthenticated()) {
+            return ResponseEntity.status(HttpStatus.UNAUTHORIZED).body(Map.of("error", "User not authenticated"));
+        }
+
+        try {
+            Page<CommentDto> comments = commentService.getCommentsByUser(authentication.getName(), pageable);
+            return ResponseEntity.ok(comments);
+        } catch (RuntimeException e) {
+            return ResponseEntity.status(HttpStatus.NOT_FOUND).body(Map.of("error", e.getMessage()));
+        }
+    }
+
+    @Operation(
+            summary = "Get pending comments",
+            description = "Retrieves all pending comments for moderation (admin only)",
+            security = @SecurityRequirement(name = "Bearer Authentication"))
+    @ApiResponses(
+            value = {
+                @ApiResponse(
+                        responseCode = "200",
+                        description = "Pending comments retrieved successfully",
+                        content = @Content(schema = @Schema(implementation = List.class))),
+                @ApiResponse(
+                        responseCode = "403",
+                        description = "Access denied - admin role required",
+                        content = @Content(schema = @Schema(implementation = Map.class)))
+            })
+    @PreAuthorize("hasRole('ADMIN')")
+    @GetMapping("/pending")
+    public ResponseEntity<?> getPendingComments() {
+        try {
+            List<CommentDto> pendingComments = commentService.getPendingComments();
+            return ResponseEntity.ok(pendingComments);
+        } catch (Exception e) {
+            return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).body(Map.of("error", "Failed to retrieve pending comments"));
+        }
+    }
+
+    @Operation(
+            summary = "Update comment",
+            description = "Updates an existing comment. Only the author can update their own comment and only if it's still pending.",
+            security = @SecurityRequirement(name = "Bearer Authentication"))
+    @ApiResponses(
+            value = {
+                @ApiResponse(
+                        responseCode = "200",
+                        description = "Comment updated successfully",
+                        content = @Content(schema = @Schema(implementation = CommentDto.class))),
+                @ApiResponse(
+                        responseCode = "400",
+                        description = "Invalid comment data",
+                        content = @Content(schema = @Schema(implementation = Map.class))),
+                @ApiResponse(
+                        responseCode = "401",
+                        description = "User not authenticated",
+                        content = @Content(schema = @Schema(implementation = Map.class))),
+                @ApiResponse(
+                        responseCode = "403",
+                        description = "User not authorized to update this comment",
+                        content = @Content(schema = @Schema(implementation = Map.class))),
+                @ApiResponse(
+                        responseCode = "404",
+                        description = "Comment not found",
+                        content = @Content(schema = @Schema(implementation = Map.class)))
+            })
+    @PutMapping("/{id}")
+    public ResponseEntity<?> updateComment(
+            @Parameter(description = "Comment ID", required = true, example = "1") @PathVariable @Positive Long id,
+            @Valid @RequestBody CommentUpdateDto commentUpdateDto,
+            Authentication authentication) {
+        if (authentication == null || !authentication.isAuthenticated()) {
+            return ResponseEntity.status(HttpStatus.UNAUTHORIZED).body(Map.of("error", "User not authenticated"));
+        }
+
+        try {
+            CommentDto updatedComment = commentService.updateComment(id, commentUpdateDto, authentication.getName());
+            return ResponseEntity.ok(updatedComment);
+        } catch (RuntimeException e) {
+            if (e.getMessage().contains("not found")) {
+                return ResponseEntity.status(HttpStatus.NOT_FOUND).body(Map.of("error", e.getMessage()));
+            } else if (e.getMessage().contains("not authorized")) {
+                return ResponseEntity.status(HttpStatus.FORBIDDEN).body(Map.of("error", e.getMessage()));
+            }
+            return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(Map.of("error", e.getMessage()));
+        }
+    }
+
+    @Operation(
+            summary = "Delete comment",
+            description = "Deletes a comment. Authors can delete their own comments, admins can delete any comment.",
+            security = @SecurityRequirement(name = "Bearer Authentication"))
+    @ApiResponses(
+            value = {
+                @ApiResponse(responseCode = "204", description = "Comment deleted successfully"),
+                @ApiResponse(
+                        responseCode = "401",
+                        description = "User not authenticated",
+                        content = @Content(schema = @Schema(implementation = Map.class))),
+                @ApiResponse(
+                        responseCode = "403",
+                        description = "User not authorized to delete this comment",
+                        content = @Content(schema = @Schema(implementation = Map.class))),
+                @ApiResponse(
+                        responseCode = "404",
+                        description = "Comment not found",
+                        content = @Content(schema = @Schema(implementation = Map.class)))
+            })
+    @DeleteMapping("/{id}")
+    public ResponseEntity<?> deleteComment(
+            @Parameter(description = "Comment ID", required = true, example = "1") @PathVariable @Positive Long id,
+            Authentication authentication) {
+        if (authentication == null || !authentication.isAuthenticated()) {
+            return ResponseEntity.status(HttpStatus.UNAUTHORIZED).body(Map.of("error", "User not authenticated"));
+        }
+
+        try {
+            // Get user role for authorization
+            User user = userRepository.findByUsername(authentication.getName())
+                    .orElseThrow(() -> new RuntimeException("User not found"));
+            
+            commentService.deleteComment(id, authentication.getName(), user.getRole());
+            return ResponseEntity.noContent().build();
+        } catch (RuntimeException e) {
+            if (e.getMessage().contains("not found")) {
+                return ResponseEntity.status(HttpStatus.NOT_FOUND).body(Map.of("error", e.getMessage()));
+            } else if (e.getMessage().contains("not authorized")) {
+                return ResponseEntity.status(HttpStatus.FORBIDDEN).body(Map.of("error", e.getMessage()));
+            }
+            return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(Map.of("error", e.getMessage()));
+        }
+    }
+
+    @Operation(
+            summary = "Approve comment",
+            description = "Approves a pending comment (admin only)",
+            security = @SecurityRequirement(name = "Bearer Authentication"))
+    @ApiResponses(
+            value = {
+                @ApiResponse(
+                        responseCode = "200",
+                        description = "Comment approved successfully",
+                        content = @Content(schema = @Schema(implementation = CommentDto.class))),
+                @ApiResponse(
+                        responseCode = "400",
+                        description = "Comment cannot be approved",
+                        content = @Content(schema = @Schema(implementation = Map.class))),
+                @ApiResponse(
+                        responseCode = "403",
+                        description = "Access denied - admin role required",
+                        content = @Content(schema = @Schema(implementation = Map.class))),
+                @ApiResponse(
+                        responseCode = "404",
+                        description = "Comment not found",
+                        content = @Content(schema = @Schema(implementation = Map.class)))
+            })
+    @PreAuthorize("hasRole('ADMIN')")
+    @PostMapping("/{id}/approve")
+    public ResponseEntity<?> approveComment(
+            @Parameter(description = "Comment ID", required = true, example = "1") @PathVariable @Positive Long id) {
+        try {
+            CommentDto approvedComment = commentService.approveComment(id);
+            return ResponseEntity.ok(approvedComment);
+        } catch (RuntimeException e) {
+            if (e.getMessage().contains("not found")) {
+                return ResponseEntity.status(HttpStatus.NOT_FOUND).body(Map.of("error", e.getMessage()));
+            }
+            return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(Map.of("error", e.getMessage()));
+        }
+    }
+
+    @Operation(
+            summary = "Reject comment",
+            description = "Rejects a pending comment (admin only)",
+            security = @SecurityRequirement(name = "Bearer Authentication"))
+    @ApiResponses(
+            value = {
+                @ApiResponse(responseCode = "204", description = "Comment rejected successfully"),
+                @ApiResponse(
+                        responseCode = "400",
+                        description = "Comment cannot be rejected",
+                        content = @Content(schema = @Schema(implementation = Map.class))),
+                @ApiResponse(
+                        responseCode = "403",
+                        description = "Access denied - admin role required",
+                        content = @Content(schema = @Schema(implementation = Map.class))),
+                @ApiResponse(
+                        responseCode = "404",
+                        description = "Comment not found",
+                        content = @Content(schema = @Schema(implementation = Map.class)))
+            })
+    @PreAuthorize("hasRole('ADMIN')")
+    @PostMapping("/{id}/reject")
+    public ResponseEntity<?> rejectComment(
+            @Parameter(description = "Comment ID", required = true, example = "1") @PathVariable @Positive Long id) {
+        try {
+            commentService.rejectComment(id);
+            return ResponseEntity.noContent().build();
+        } catch (RuntimeException e) {
+            if (e.getMessage().contains("not found")) {
+                return ResponseEntity.status(HttpStatus.NOT_FOUND).body(Map.of("error", e.getMessage()));
+            }
+            return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(Map.of("error", e.getMessage()));
+        }
+    }
+
+    @Operation(
+            summary = "Get average rating for a book",
+            description = "Retrieves the average rating for a specific book based on published comments")
+    @ApiResponses(
+            value = {
+                @ApiResponse(
+                        responseCode = "200",
+                        description = "Average rating retrieved successfully",
+                        content = @Content(schema = @Schema(implementation = Map.class))),
+                @ApiResponse(
+                        responseCode = "404",
+                        description = "Book not found",
+                        content = @Content(schema = @Schema(implementation = Map.class)))
+            })
+    @GetMapping("/book/{bookId}/average-rating")
+    public ResponseEntity<?> getAverageRatingForBook(
+            @Parameter(description = "Book ID", required = true, example = "1") @PathVariable @Positive Long bookId) {
+        try {
+            Optional<Double> averageRating = commentService.getAverageRatingForBook(bookId);
+            long commentCount = commentService.getCommentCountForBook(bookId);
+            
+            Map<String, Object> response = Map.of(
+                    "averageRating", averageRating.orElse(0.0),
+                    "commentCount", commentCount
+            );
+            
+            return ResponseEntity.ok(response);
+        } catch (RuntimeException e) {
+            return ResponseEntity.status(HttpStatus.NOT_FOUND).body(Map.of("error", e.getMessage()));
+        }
+    }
+}

--- a/backend/src/main/java/com/aaron212/onlinelibrarymanagement/backend/dto/CommentCreateDto.java
+++ b/backend/src/main/java/com/aaron212/onlinelibrarymanagement/backend/dto/CommentCreateDto.java
@@ -1,0 +1,27 @@
+package com.aaron212.onlinelibrarymanagement.backend.dto;
+
+import jakarta.validation.constraints.*;
+import io.swagger.v3.oas.annotations.media.Schema;
+
+import java.math.BigDecimal;
+
+@Schema(description = "Data transfer object for creating a new comment")
+public record CommentCreateDto(
+    
+    @Schema(description = "Book ID to comment on", example = "1", required = true)
+    @NotNull(message = "Book ID is required")
+    @Positive(message = "Book ID must be positive")
+    Long bookId,
+    
+    @Schema(description = "Comment content", example = "This is a great book!", required = true)
+    @NotBlank(message = "Comment content is required")
+    @Size(min = 10, max = 1000, message = "Comment content must be between 10 and 1000 characters")
+    String content,
+    
+    @Schema(description = "Rating (0.0 to 5.0)", example = "4.5", required = false)
+    @DecimalMin(value = "0.0", message = "Rating must be at least 0.0")
+    @DecimalMax(value = "5.0", message = "Rating must be at most 5.0")
+    @Digits(integer = 1, fraction = 1, message = "Rating must have at most 1 digit before and 1 digit after decimal point")
+    BigDecimal rating
+) {
+}

--- a/backend/src/main/java/com/aaron212/onlinelibrarymanagement/backend/dto/CommentDto.java
+++ b/backend/src/main/java/com/aaron212/onlinelibrarymanagement/backend/dto/CommentDto.java
@@ -1,0 +1,39 @@
+package com.aaron212.onlinelibrarymanagement.backend.dto;
+
+import com.aaron212.onlinelibrarymanagement.backend.model.Comment;
+import io.swagger.v3.oas.annotations.media.Schema;
+
+import java.math.BigDecimal;
+import java.time.LocalDateTime;
+
+@Schema(description = "Data transfer object for comment responses")
+public record CommentDto(
+    
+    @Schema(description = "Comment ID", example = "1")
+    Long id,
+    
+    @Schema(description = "User ID who made the comment", example = "123")
+    Long userId,
+    
+    @Schema(description = "Username who made the comment", example = "john_doe")
+    String username,
+    
+    @Schema(description = "Book ID that was commented on", example = "456")
+    Long bookId,
+    
+    @Schema(description = "Book title that was commented on", example = "The Great Gatsby")
+    String bookTitle,
+    
+    @Schema(description = "Comment content", example = "This is a great book!")
+    String content,
+    
+    @Schema(description = "Rating given (0.0 to 5.0)", example = "4.5")
+    BigDecimal rating,
+    
+    @Schema(description = "When the comment was created", example = "2023-12-15T10:30:00")
+    LocalDateTime createTime,
+    
+    @Schema(description = "Comment status", example = "PUBLISHED")
+    Comment.Status status
+) {
+}

--- a/backend/src/main/java/com/aaron212/onlinelibrarymanagement/backend/dto/CommentUpdateDto.java
+++ b/backend/src/main/java/com/aaron212/onlinelibrarymanagement/backend/dto/CommentUpdateDto.java
@@ -1,0 +1,22 @@
+package com.aaron212.onlinelibrarymanagement.backend.dto;
+
+import jakarta.validation.constraints.*;
+import io.swagger.v3.oas.annotations.media.Schema;
+
+import java.math.BigDecimal;
+
+@Schema(description = "Data transfer object for updating an existing comment")
+public record CommentUpdateDto(
+    
+    @Schema(description = "Updated comment content", example = "This is an updated comment!", required = true)
+    @NotBlank(message = "Comment content is required")
+    @Size(min = 10, max = 1000, message = "Comment content must be between 10 and 1000 characters")
+    String content,
+    
+    @Schema(description = "Updated rating (0.0 to 5.0)", example = "4.0", required = false)
+    @DecimalMin(value = "0.0", message = "Rating must be at least 0.0")
+    @DecimalMax(value = "5.0", message = "Rating must be at most 5.0")
+    @Digits(integer = 1, fraction = 1, message = "Rating must have at most 1 digit before and 1 digit after decimal point")
+    BigDecimal rating
+) {
+}

--- a/backend/src/main/java/com/aaron212/onlinelibrarymanagement/backend/repository/CommentRepository.java
+++ b/backend/src/main/java/com/aaron212/onlinelibrarymanagement/backend/repository/CommentRepository.java
@@ -1,0 +1,43 @@
+package com.aaron212.onlinelibrarymanagement.backend.repository;
+
+import com.aaron212.onlinelibrarymanagement.backend.model.Comment;
+import com.aaron212.onlinelibrarymanagement.backend.model.Book;
+import com.aaron212.onlinelibrarymanagement.backend.model.User;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+import java.util.Optional;
+
+@Repository
+public interface CommentRepository extends JpaRepository<Comment, Long> {
+    
+    // Find comments by book with pagination
+    Page<Comment> findByBookAndStatus(Book book, Comment.Status status, Pageable pageable);
+    
+    // Find comments by user with pagination
+    Page<Comment> findByUserAndStatus(User user, Comment.Status status, Pageable pageable);
+    
+    // Find all published comments for a book
+    List<Comment> findByBookAndStatusOrderByCreateTimeDesc(Book book, Comment.Status status);
+    
+    // Find pending comments for moderation
+    List<Comment> findByStatusOrderByCreateTimeAsc(Comment.Status status);
+    
+    // Check if user has already commented on a book
+    boolean existsByUserAndBook(User user, Book book);
+    
+    // Get average rating for a book
+    @Query("SELECT AVG(c.rating) FROM Comment c WHERE c.book = :book AND c.status = :status AND c.rating IS NOT NULL")
+    Optional<Double> findAverageRatingByBookAndStatus(@Param("book") Book book, @Param("status") Comment.Status status);
+    
+    // Count comments by book and status
+    long countByBookAndStatus(Book book, Comment.Status status);
+    
+    // Count comments by user and status
+    long countByUserAndStatus(User user, Comment.Status status);
+}

--- a/backend/src/main/java/com/aaron212/onlinelibrarymanagement/backend/service/CommentService.java
+++ b/backend/src/main/java/com/aaron212/onlinelibrarymanagement/backend/service/CommentService.java
@@ -1,0 +1,189 @@
+package com.aaron212.onlinelibrarymanagement.backend.service;
+
+import com.aaron212.onlinelibrarymanagement.backend.dto.CommentCreateDto;
+import com.aaron212.onlinelibrarymanagement.backend.dto.CommentDto;
+import com.aaron212.onlinelibrarymanagement.backend.dto.CommentUpdateDto;
+import com.aaron212.onlinelibrarymanagement.backend.model.Book;
+import com.aaron212.onlinelibrarymanagement.backend.model.Comment;
+import com.aaron212.onlinelibrarymanagement.backend.model.User;
+import com.aaron212.onlinelibrarymanagement.backend.repository.BookRepository;
+import com.aaron212.onlinelibrarymanagement.backend.repository.CommentRepository;
+import com.aaron212.onlinelibrarymanagement.backend.repository.UserRepository;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+import java.util.Optional;
+import java.util.stream.Collectors;
+
+@Service
+@Transactional
+public class CommentService {
+
+    private final CommentRepository commentRepository;
+    private final BookRepository bookRepository;
+    private final UserRepository userRepository;
+
+    public CommentService(CommentRepository commentRepository, BookRepository bookRepository, UserRepository userRepository) {
+        this.commentRepository = commentRepository;
+        this.bookRepository = bookRepository;
+        this.userRepository = userRepository;
+    }
+
+    // Create a new comment
+    public CommentDto createComment(CommentCreateDto commentCreateDto, String username) {
+        User user = userRepository.findByUsername(username)
+                .orElseThrow(() -> new RuntimeException("User not found: " + username));
+        
+        Book book = bookRepository.findById(commentCreateDto.bookId())
+                .orElseThrow(() -> new RuntimeException("Book not found with id: " + commentCreateDto.bookId()));
+
+        // Check if user has already commented on this book
+        if (commentRepository.existsByUserAndBook(user, book)) {
+            throw new RuntimeException("User has already commented on this book");
+        }
+
+        Comment comment = new Comment();
+        comment.setUser(user);
+        comment.setBook(book);
+        comment.setContent(commentCreateDto.content());
+        comment.setRating(commentCreateDto.rating());
+        comment.setStatus(Comment.Status.PENDING); // Comments need approval by default
+
+        Comment savedComment = commentRepository.save(comment);
+        return convertToDto(savedComment);
+    }
+
+    // Get comment by ID
+    @Transactional(readOnly = true)
+    public Optional<CommentDto> getCommentById(Long id) {
+        return commentRepository.findById(id).map(this::convertToDto);
+    }
+
+    // Get all published comments for a book with pagination
+    @Transactional(readOnly = true)
+    public Page<CommentDto> getPublishedCommentsByBook(Long bookId, Pageable pageable) {
+        Book book = bookRepository.findById(bookId)
+                .orElseThrow(() -> new RuntimeException("Book not found with id: " + bookId));
+        
+        return commentRepository.findByBookAndStatus(book, Comment.Status.PUBLISHED, pageable)
+                .map(this::convertToDto);
+    }
+
+    // Get comments by user with pagination
+    @Transactional(readOnly = true)
+    public Page<CommentDto> getCommentsByUser(String username, Pageable pageable) {
+        User user = userRepository.findByUsername(username)
+                .orElseThrow(() -> new RuntimeException("User not found: " + username));
+        
+        return commentRepository.findByUserAndStatus(user, Comment.Status.PUBLISHED, pageable)
+                .map(this::convertToDto);
+    }
+
+    // Get pending comments for moderation (admin only)
+    @Transactional(readOnly = true)
+    public List<CommentDto> getPendingComments() {
+        return commentRepository.findByStatusOrderByCreateTimeAsc(Comment.Status.PENDING)
+                .stream()
+                .map(this::convertToDto)
+                .collect(Collectors.toList());
+    }
+
+    // Update comment (only by the author and only if pending)
+    public CommentDto updateComment(Long id, CommentUpdateDto commentUpdateDto, String username) {
+        Comment comment = commentRepository.findById(id)
+                .orElseThrow(() -> new RuntimeException("Comment not found with id: " + id));
+
+        // Check if user is the author of the comment
+        if (!comment.getUser().getUsername().equals(username)) {
+            throw new RuntimeException("User is not authorized to update this comment");
+        }
+
+        // Only allow updates if comment is still pending
+        if (comment.getStatus() != Comment.Status.PENDING) {
+            throw new RuntimeException("Only pending comments can be updated");
+        }
+
+        comment.setContent(commentUpdateDto.content());
+        comment.setRating(commentUpdateDto.rating());
+
+        Comment updatedComment = commentRepository.save(comment);
+        return convertToDto(updatedComment);
+    }
+
+    // Delete comment (by author or admin)
+    public void deleteComment(Long id, String username, User.Role userRole) {
+        Comment comment = commentRepository.findById(id)
+                .orElseThrow(() -> new RuntimeException("Comment not found with id: " + id));
+
+        // Check if user is authorized to delete (author or admin)
+        if (!comment.getUser().getUsername().equals(username) && userRole != User.Role.ADMIN) {
+            throw new RuntimeException("User is not authorized to delete this comment");
+        }
+
+        comment.setStatus(Comment.Status.DELETED);
+        commentRepository.save(comment);
+    }
+
+    // Approve comment (admin only)
+    public CommentDto approveComment(Long id) {
+        Comment comment = commentRepository.findById(id)
+                .orElseThrow(() -> new RuntimeException("Comment not found with id: " + id));
+
+        if (comment.getStatus() != Comment.Status.PENDING) {
+            throw new RuntimeException("Only pending comments can be approved");
+        }
+
+        comment.setStatus(Comment.Status.PUBLISHED);
+        Comment approvedComment = commentRepository.save(comment);
+        return convertToDto(approvedComment);
+    }
+
+    // Reject comment (admin only)
+    public void rejectComment(Long id) {
+        Comment comment = commentRepository.findById(id)
+                .orElseThrow(() -> new RuntimeException("Comment not found with id: " + id));
+
+        if (comment.getStatus() != Comment.Status.PENDING) {
+            throw new RuntimeException("Only pending comments can be rejected");
+        }
+
+        comment.setStatus(Comment.Status.DELETED);
+        commentRepository.save(comment);
+    }
+
+    // Get average rating for a book
+    @Transactional(readOnly = true)
+    public Optional<Double> getAverageRatingForBook(Long bookId) {
+        Book book = bookRepository.findById(bookId)
+                .orElseThrow(() -> new RuntimeException("Book not found with id: " + bookId));
+        
+        return commentRepository.findAverageRatingByBookAndStatus(book, Comment.Status.PUBLISHED);
+    }
+
+    // Get comment count for a book
+    @Transactional(readOnly = true)
+    public long getCommentCountForBook(Long bookId) {
+        Book book = bookRepository.findById(bookId)
+                .orElseThrow(() -> new RuntimeException("Book not found with id: " + bookId));
+        
+        return commentRepository.countByBookAndStatus(book, Comment.Status.PUBLISHED);
+    }
+
+    // Convert Comment entity to DTO
+    private CommentDto convertToDto(Comment comment) {
+        return new CommentDto(
+                comment.getId(),
+                comment.getUser().getId(),
+                comment.getUser().getUsername(),
+                comment.getBook().getId(),
+                comment.getBook().getTitle(),
+                comment.getContent(),
+                comment.getRating(),
+                comment.getCreateTime(),
+                comment.getStatus()
+        );
+    }
+}


### PR DESCRIPTION
A `CommentController` was added to the backend, establishing a comprehensive comment management system. This involved creating several new components:

*   `CommentRepository.java`: A JPA repository for `Comment` entities, including custom queries for filtering and statistics.
*   `CommentService.java`: The business logic layer, handling comment creation, retrieval, updates, and moderation.
*   `CommentController.java`: The REST controller exposing API endpoints for comment operations.
*   `CommentCreateDto.java`, `CommentUpdateDto.java`, `CommentDto.java`: Data transfer objects for comment creation, updates, and responses, respectively, with validation rules.

The implemented functionality includes:
*   **CRUD Operations**: Create, retrieve (by ID, book, user, or current user), update, and delete comments.
*   **Moderation**: Admin-only endpoints to approve or reject `PENDING` comments.
*   **Security**: JWT authentication and role-based authorization, allowing users to manage their own comments and admins to moderate all.
*   **Business Rules**: Comments are initially `PENDING`, only `PENDING` comments can be updated, and a user can only comment once per book.
*   **Statistics**: Endpoints to retrieve average rating and comment count for a book.

The new components integrate with existing `Book` and `User` models. The backend compiles successfully, and all changes were committed to the `feature/add-comment-controller` branch.