### PR TITLE
Remove conflicting dashboard from sidebar

### DIFF
--- a/frontend/src/components/AppSidebar.vue
+++ b/frontend/src/components/AppSidebar.vue
@@ -50,12 +50,6 @@ const navigationItems = computed(() => [
     icon: Home,
   },
   {
-    title: 'Dashboard',
-    url: authStore.isAuthenticated && authStore.isAdmin() ? '/admin/dashboard' : '/dashboard',
-    icon: Gauge,
-    requiresAuth: true,
-  },
-  {
     title: 'Books',
     url: '/books',
     icon: BookOpen,

--- a/frontend/src/components/AppSidebar.vue
+++ b/frontend/src/components/AppSidebar.vue
@@ -50,6 +50,13 @@ const navigationItems = computed(() => [
     icon: Home,
   },
   {
+    title: 'Dashboard',
+    url: '/dashboard',
+    icon: Gauge,
+    requiresAuth: true,
+    hideForAdmin: true, // Hide this for admins since they have Admin Dashboard
+  },
+  {
     title: 'Books',
     url: '/books',
     icon: BookOpen,
@@ -139,7 +146,15 @@ const isAdmin = computed(() => {
 })
 
 const filteredNavigationItems = computed(() => {
-  return navigationItems.value.filter((item) => !item.requiresAuth || authStore.isAuthenticated)
+  return navigationItems.value.filter((item) => {
+    // Filter out items that require auth when user is not authenticated
+    if (item.requiresAuth && !authStore.isAuthenticated) return false
+    
+    // Filter out items that should be hidden for admins when user is admin
+    if (item.hideForAdmin && authStore.isAuthenticated && authStore.isAdmin()) return false
+    
+    return true
+  })
 })
 
 const filteredLibraryItems = computed(() => {


### PR DESCRIPTION
The `AppSidebar.vue` component's navigation logic was updated to resolve conflicting "Dashboard" entries. Initially, the "Dashboard" navigation item was configured to route both regular users and administrators, causing administrators to see two distinct dashboard options.

To address this, the "Dashboard" item's `url` in `AppSidebar.vue` was simplified to `/dashboard`, and a new `hideForAdmin: true` property was introduced to it.

Subsequently, the `filteredNavigationItems` computed property in `AppSidebar.vue` was modified. It now filters out navigation items that:
*   Have `requiresAuth` set to `true` if the user is unauthenticated.
*   Have `hideForAdmin` set to `true` if the authenticated user is an administrator.

This ensures regular users see a "Dashboard" button, while administrators exclusively see the "Admin Dashboard" button in the Administration section, providing a clean, role-appropriate navigation experience without duplicate entries.