### PR TITLE
Fix admin notice addition in frontend

### DIFF
--- a/frontend/src/lib/api/services/notices.ts
+++ b/frontend/src/lib/api/services/notices.ts
@@ -19,7 +19,7 @@ export class NoticesService {
   }
 
   async create(noticeData: NoticeCreateDto): Promise<MessageResponse> {
-    return apiClient.post<MessageResponse>(this.basePath, noticeData)
+    return apiClient.post<MessageResponse>(`${this.basePath}/create`, noticeData)
   }
 
   async update(id: number, noticeData: NoticeUpdateDto): Promise<MessageResponse> {


### PR DESCRIPTION
Fix #60

A discrepancy in API endpoint paths prevented administrators from adding notices via the frontend.

The backend expected new notice creation requests at `POST /api/v1/notices/create`, while the frontend was sending them to `POST /api/v1/notices`.

To resolve this, the `create` method in `frontend/src/lib/api/services/notices.ts` was updated.

- The `apiClient.post` call was modified to append `/create` to the `this.basePath`, aligning the frontend's request path with the backend's expected endpoint.

This change ensures that authenticated administrators can now successfully add notices through the user interface.