### PR TITLE
Fix admin panel statistics loading

### DIFF
--- a/backend/src/main/java/com/aaron212/onlinelibrarymanagement/backend/controller/StatisticsController.java
+++ b/backend/src/main/java/com/aaron212/onlinelibrarymanagement/backend/controller/StatisticsController.java
@@ -1,6 +1,7 @@
 package com.aaron212.onlinelibrarymanagement.backend.controller;
 
 import com.aaron212.onlinelibrarymanagement.backend.dto.BookStatisticsDto;
+import com.aaron212.onlinelibrarymanagement.backend.dto.LibraryStatisticsDto;
 import com.aaron212.onlinelibrarymanagement.backend.dto.TopBooksRequestDto;
 import com.aaron212.onlinelibrarymanagement.backend.service.StatisticsService;
 import io.swagger.v3.oas.annotations.Operation;
@@ -53,6 +54,37 @@ public class StatisticsController {
         } catch (Exception e) {
             return ResponseEntity.status(HttpStatus.BAD_REQUEST)
                     .body(Map.of("error", "Failed to retrieve top borrowed books"));
+        }
+    }
+
+    @PostMapping("/top-books")
+    public ResponseEntity<?> getTopBooksAlias(@Valid @RequestBody TopBooksRequestDto requestDto) {
+        return getTopBorrowedBooks(requestDto);
+    }
+
+    @Operation(
+            summary = "Get aggregated book statistics",
+            description = "Returns high-level statistics about the book collection and borrowing activity",
+            security = @SecurityRequirement(name = "Bearer Authentication"))
+    @ApiResponses(
+            value = {
+                @ApiResponse(
+                        responseCode = "200",
+                        description = "Statistics retrieved successfully",
+                        content = @Content(schema = @Schema(implementation = LibraryStatisticsDto.class))),
+                @ApiResponse(
+                        responseCode = "500",
+                        description = "Internal server error",
+                        content = @Content(schema = @Schema(implementation = Map.class))),
+            })
+    @GetMapping("/books")
+    public ResponseEntity<?> getBookStatistics() {
+        try {
+            LibraryStatisticsDto stats = statisticsService.getLibraryStatistics();
+            return ResponseEntity.ok(stats);
+        } catch (Exception e) {
+            return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR)
+                    .body(Map.of("error", "Failed to retrieve book statistics"));
         }
     }
 

--- a/backend/src/main/java/com/aaron212/onlinelibrarymanagement/backend/dto/LibraryStatisticsDto.java
+++ b/backend/src/main/java/com/aaron212/onlinelibrarymanagement/backend/dto/LibraryStatisticsDto.java
@@ -1,0 +1,16 @@
+package com.aaron212.onlinelibrarymanagement.backend.dto;
+
+/**
+ * Aggregated statistics for the entire library collection.
+ * <p>
+ * The field names match the expectations of the front-end `BookStatisticsDto` interface
+ * so that the JSON returned by the backend can be consumed directly.
+ */
+public record LibraryStatisticsDto(
+        Long totalBooks,
+        Long availableBooks,
+        Long borrowedBooks,
+        Long totalBorrows,
+        Long activeBorrows,
+        Long overdueBorrows) {
+}

--- a/backend/src/main/java/com/aaron212/onlinelibrarymanagement/backend/repository/BookCopyRepository.java
+++ b/backend/src/main/java/com/aaron212/onlinelibrarymanagement/backend/repository/BookCopyRepository.java
@@ -8,4 +8,7 @@ import java.util.List;
 
 public interface BookCopyRepository extends JpaRepository<BookCopy, Long> {
     List<BookCopy> findByBook(Book book);
+
+    /* Counts book copies by their current status */
+    long countByStatus(BookCopy.Status status);
 }

--- a/backend/src/main/java/com/aaron212/onlinelibrarymanagement/backend/repository/BorrowRepository.java
+++ b/backend/src/main/java/com/aaron212/onlinelibrarymanagement/backend/repository/BorrowRepository.java
@@ -41,4 +41,7 @@ public interface BorrowRepository extends JpaRepository<Borrow, Long> {
            "b.status as status, b.fine as fine " +
            "FROM Borrow b WHERE b.user.id = :userId ORDER BY b.borrowTime DESC")
     List<BorrowProjection> findBorrowProjectionsByUserId(@Param("userId") Long userId);
+
+    /* Counts borrows by their current status */
+    long countByStatus(Borrow.Status status);
 }

--- a/backend/src/main/java/com/aaron212/onlinelibrarymanagement/backend/service/StatisticsService.java
+++ b/backend/src/main/java/com/aaron212/onlinelibrarymanagement/backend/service/StatisticsService.java
@@ -1,6 +1,7 @@
 package com.aaron212.onlinelibrarymanagement.backend.service;
 
 import com.aaron212.onlinelibrarymanagement.backend.dto.BookStatisticsDto;
+import com.aaron212.onlinelibrarymanagement.backend.dto.LibraryStatisticsDto;
 import com.aaron212.onlinelibrarymanagement.backend.mapper.BookMapper;
 import com.aaron212.onlinelibrarymanagement.backend.model.*;
 import com.aaron212.onlinelibrarymanagement.backend.repository.*;
@@ -120,5 +121,29 @@ public class StatisticsService {
         analysis.put("registrationCount", registrationCount);
         analysis.put("activeUserCount", activeUserCount);
         return analysis;
+    }
+
+    /**
+     * Returns high-level aggregated statistics about the library collection and borrowing activity. The
+     * returned object is shaped to match the fields expected by the front-end `BookStatisticsDto` TS
+     * interface so that no changes are required on the UI side.
+     */
+    public LibraryStatisticsDto getLibraryStatistics() {
+        long totalBooks = bookRepository.count();
+
+        long availableBooks = bookCopyRepository.countByStatus(BookCopy.Status.AVAILABLE);
+        long borrowedBooks = bookCopyRepository.countByStatus(BookCopy.Status.BORROWED);
+
+        long totalBorrows = borrowRepository.count();
+        long activeBorrows = borrowRepository.countByStatus(Borrow.Status.BORROWED);
+        long overdueBorrows = borrowRepository.countByStatus(Borrow.Status.OVERDUE);
+
+        return new LibraryStatisticsDto(
+                totalBooks,
+                availableBooks,
+                borrowedBooks,
+                totalBorrows,
+                activeBorrows,
+                overdueBorrows);
     }
 }

--- a/backend/src/main/java/com/aaron212/onlinelibrarymanagement/backend/service/StatisticsService.java
+++ b/backend/src/main/java/com/aaron212/onlinelibrarymanagement/backend/service/StatisticsService.java
@@ -129,7 +129,7 @@ public class StatisticsService {
      * interface so that no changes are required on the UI side.
      */
     public LibraryStatisticsDto getLibraryStatistics() {
-        long totalBooks = bookRepository.count();
+        long totalBooks = bookCopyRepository.count();
 
         long availableBooks = bookCopyRepository.countByStatus(BookCopy.Status.AVAILABLE);
         long borrowedBooks = bookCopyRepository.countByStatus(BookCopy.Status.BORROWED);


### PR DESCRIPTION
Fix #62 

The admin panel failed to load statistics because the backend lacked the expected `/api/v1/statistics/books` and `/api/v1/statistics/top-books` endpoints, and the necessary aggregate calculations.

To address this:
*   A new DTO, `backend/src/main/java/com/aaron212/onlinelibrarymanagement/backend/dto/LibraryStatisticsDto.java`, was introduced. Its fields align with the frontend's expected `BookStatisticsDto` interface.
*   Repository helper methods `countByStatus(...)` were added to `BookCopyRepository` and `BorrowRepository` to facilitate counting entities by their status.
*   `StatisticsService%23getLibraryStatistics()` was implemented to compute high-level library statistics using the new repository helpers.
*   `StatisticsController` was updated:
    *   A `GET /api/v1/statistics/books` endpoint was added to expose the `LibraryStatisticsDto`.
    *   A `POST /api/v1/statistics/top-books` endpoint was added as an alias to the existing `getTopBorrowedBooks` logic, matching the frontend's POST request.

These changes enable the frontend to consume the statistics without requiring any modifications.