### PR TITLE
Fix issue in backend and frontend

### DIFF
--- a/backend/src/main/java/com/aaron212/onlinelibrarymanagement/backend/controller/BorrowController.java
+++ b/backend/src/main/java/com/aaron212/onlinelibrarymanagement/backend/controller/BorrowController.java
@@ -18,6 +18,9 @@ import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import jakarta.validation.constraints.Positive;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.PageRequest;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.prepost.PreAuthorize;
@@ -461,5 +464,27 @@ public class BorrowController {
         } catch (Exception e) {
             return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(Map.of("error", e.getMessage()));
         }
+    }
+
+    @Operation(
+            summary = "Get borrowings for current user (stub)",
+            description = "Temporary stub endpoint to align with frontend '/borrow/user' path. Returns an empty page until full implementation is provided.")
+    @ApiResponses(
+            value = {
+                @ApiResponse(responseCode = "200", description = "Request successful", content = @Content(schema = @Schema(implementation = Page.class))),
+                @ApiResponse(responseCode = "401", description = "User not authenticated", content = @Content(schema = @Schema(implementation = Map.class)))
+            })
+    @GetMapping("/user")
+    public ResponseEntity<Page<?>> getCurrentUserBorrowingsPaged(
+            Authentication authentication,
+            @Parameter(description = "Page number", example = "0") @RequestParam(defaultValue = "0") int page,
+            @Parameter(description = "Page size", example = "10") @RequestParam(defaultValue = "10") int size) {
+        if (authentication == null || !authentication.isAuthenticated()) {
+            return ResponseEntity.status(HttpStatus.UNAUTHORIZED).body(Map.of("error", "User not authenticated"));
+        }
+
+        // TODO: Replace with real implementation once pagination is supported in the service layer
+        Page<?> emptyPage = new PageImpl<>(List.of(), PageRequest.of(page, size), 0);
+        return ResponseEntity.ok(emptyPage);
     }
 }

--- a/backend/src/main/java/com/aaron212/onlinelibrarymanagement/backend/controller/BorrowController.java
+++ b/backend/src/main/java/com/aaron212/onlinelibrarymanagement/backend/controller/BorrowController.java
@@ -475,7 +475,7 @@ public class BorrowController {
                 @ApiResponse(responseCode = "401", description = "User not authenticated", content = @Content(schema = @Schema(implementation = Map.class)))
             })
     @GetMapping("/user")
-    public ResponseEntity<Page<?>> getCurrentUserBorrowingsPaged(
+    public ResponseEntity<?> getCurrentUserBorrowingsPaged(
             Authentication authentication,
             @Parameter(description = "Page number", example = "0") @RequestParam(defaultValue = "0") int page,
             @Parameter(description = "Page size", example = "10") @RequestParam(defaultValue = "10") int size) {

--- a/backend/src/main/java/com/aaron212/onlinelibrarymanagement/backend/controller/FavoritesController.java
+++ b/backend/src/main/java/com/aaron212/onlinelibrarymanagement/backend/controller/FavoritesController.java
@@ -1,0 +1,72 @@
+package com.aaron212.onlinelibrarymanagement.backend.controller;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.Authentication;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
+import java.util.Map;
+
+@RestController
+@RequestMapping("/api/v1/favorites")
+@Tag(name = "Favorites", description = "Stub endpoints for user favorite books. Full implementation pending.")
+public class FavoritesController {
+
+    @Operation(
+            summary = "Get current user's favorites (stub)",
+            description = "Returns an empty paginated response to satisfy frontend routing until the feature is fully implemented.")
+    @ApiResponses(
+            value = {
+                @ApiResponse(responseCode = "200", description = "Request successful", content = @Content(schema = @Schema(implementation = Page.class))),
+                @ApiResponse(responseCode = "401", description = "User not authenticated", content = @Content(schema = @Schema(implementation = Map.class)))
+            })
+    @GetMapping("/user")
+    public ResponseEntity<Page<?>> getCurrentUserFavorites(
+            Authentication authentication,
+            @RequestParam(defaultValue = "0") int page,
+            @RequestParam(defaultValue = "10") int size) {
+        if (authentication == null || !authentication.isAuthenticated()) {
+            return ResponseEntity.status(401).body(Map.of("error", "User not authenticated"));
+        }
+
+        Page<?> emptyPage = new PageImpl<>(List.of(), PageRequest.of(page, size), 0);
+        return ResponseEntity.ok(emptyPage);
+    }
+
+    @Operation(
+            summary = "Add favorite (stub)",
+            description = "Adds a favorite book for the current user. Currently returns success without effect.")
+    @PostMapping
+    public ResponseEntity<Map<String, String>> addFavorite(Authentication authentication) {
+        if (authentication == null || !authentication.isAuthenticated()) {
+            return ResponseEntity.status(401).body(Map.of("error", "User not authenticated"));
+        }
+        return ResponseEntity.ok(Map.of("message", "Favorite added (stub)"));
+    }
+
+    @Operation(
+            summary = "Remove favorite (stub)",
+            description = "Removes a favorite by ID. Currently returns success without effect.")
+    @DeleteMapping("/{favoriteId}")
+    public ResponseEntity<Map<String, String>> removeFavorite(Authentication authentication, @PathVariable Long favoriteId) {
+        if (authentication == null || !authentication.isAuthenticated()) {
+            return ResponseEntity.status(401).body(Map.of("error", "User not authenticated"));
+        }
+        return ResponseEntity.ok(Map.of("message", "Favorite removed (stub)"));
+    }
+}

--- a/backend/src/main/java/com/aaron212/onlinelibrarymanagement/backend/controller/FavoritesController.java
+++ b/backend/src/main/java/com/aaron212/onlinelibrarymanagement/backend/controller/FavoritesController.java
@@ -36,7 +36,7 @@ public class FavoritesController {
                 @ApiResponse(responseCode = "401", description = "User not authenticated", content = @Content(schema = @Schema(implementation = Map.class)))
             })
     @GetMapping("/user")
-    public ResponseEntity<Page<?>> getCurrentUserFavorites(
+    public ResponseEntity<?> getCurrentUserFavorites(
             Authentication authentication,
             @RequestParam(defaultValue = "0") int page,
             @RequestParam(defaultValue = "10") int size) {

--- a/backend/src/main/java/com/aaron212/onlinelibrarymanagement/backend/controller/FeeController.java
+++ b/backend/src/main/java/com/aaron212/onlinelibrarymanagement/backend/controller/FeeController.java
@@ -17,6 +17,9 @@ import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import jakarta.validation.constraints.Positive;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.PageRequest;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.prepost.PreAuthorize;
@@ -181,5 +184,27 @@ public class FeeController {
         } catch (Exception e) {
             return ResponseEntity.status(HttpStatus.NOT_FOUND).body(Map.of("error", "User not found"));
         }
+    }
+
+    @Operation(
+            summary = "Get all fees for current user (stub)",
+            description = "Temporary stub endpoint to align with frontend '/fees/user' path. Returns an empty page until full implementation is provided.")
+    @ApiResponses(
+            value = {
+                @ApiResponse(responseCode = "200", description = "Request successful", content = @Content(schema = @Schema(implementation = Page.class))),
+                @ApiResponse(responseCode = "401", description = "User not authenticated", content = @Content(schema = @Schema(implementation = Map.class)))
+            })
+    @GetMapping("/user")
+    public ResponseEntity<Page<?>> getAllFeesForCurrentUser(
+            Authentication authentication,
+            @Parameter(description = "Page number", example = "0") @RequestParam(defaultValue = "0") int page,
+            @Parameter(description = "Page size", example = "10") @RequestParam(defaultValue = "10") int size) {
+        if (authentication == null || !authentication.isAuthenticated()) {
+            return ResponseEntity.status(HttpStatus.UNAUTHORIZED).body(Map.of("error", "User not authenticated"));
+        }
+
+        // TODO: Replace with real implementation once service layer supports pagination
+        Page<?> emptyPage = new PageImpl<>(List.of(), PageRequest.of(page, size), 0);
+        return ResponseEntity.ok(emptyPage);
     }
 }

--- a/backend/src/main/java/com/aaron212/onlinelibrarymanagement/backend/controller/FeeController.java
+++ b/backend/src/main/java/com/aaron212/onlinelibrarymanagement/backend/controller/FeeController.java
@@ -195,7 +195,7 @@ public class FeeController {
                 @ApiResponse(responseCode = "401", description = "User not authenticated", content = @Content(schema = @Schema(implementation = Map.class)))
             })
     @GetMapping("/user")
-    public ResponseEntity<Page<?>> getAllFeesForCurrentUser(
+    public ResponseEntity<?> getAllFeesForCurrentUser(
             Authentication authentication,
             @Parameter(description = "Page number", example = "0") @RequestParam(defaultValue = "0") int page,
             @Parameter(description = "Page size", example = "10") @RequestParam(defaultValue = "10") int size) {

--- a/backend/src/main/java/com/aaron212/onlinelibrarymanagement/backend/controller/ReservationsController.java
+++ b/backend/src/main/java/com/aaron212/onlinelibrarymanagement/backend/controller/ReservationsController.java
@@ -30,7 +30,7 @@ public class ReservationsController {
                 @ApiResponse(responseCode = "401", description = "User not authenticated", content = @Content(schema = @Schema(implementation = Map.class)))
             })
     @GetMapping("/user")
-    public ResponseEntity<Page<?>> getCurrentUserReservations(
+    public ResponseEntity<?> getCurrentUserReservations(
             Authentication authentication,
             @RequestParam(defaultValue = "0") int page,
             @RequestParam(defaultValue = "10") int size) {

--- a/backend/src/main/java/com/aaron212/onlinelibrarymanagement/backend/controller/ReservationsController.java
+++ b/backend/src/main/java/com/aaron212/onlinelibrarymanagement/backend/controller/ReservationsController.java
@@ -1,0 +1,64 @@
+package com.aaron212.onlinelibrarymanagement.backend.controller;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.Authentication;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+import java.util.Map;
+
+@RestController
+@RequestMapping("/api/v1/reservations")
+@Tag(name = "Reservations", description = "Stub endpoints for book reservations. Full implementation pending.")
+public class ReservationsController {
+
+    @Operation(
+            summary = "Get current user's reservations (stub)",
+            description = "Returns an empty paginated response to satisfy frontend routing until the feature is fully implemented.")
+    @ApiResponses(
+            value = {
+                @ApiResponse(responseCode = "200", description = "Request successful", content = @Content(schema = @Schema(implementation = Page.class))),
+                @ApiResponse(responseCode = "401", description = "User not authenticated", content = @Content(schema = @Schema(implementation = Map.class)))
+            })
+    @GetMapping("/user")
+    public ResponseEntity<Page<?>> getCurrentUserReservations(
+            Authentication authentication,
+            @RequestParam(defaultValue = "0") int page,
+            @RequestParam(defaultValue = "10") int size) {
+        if (authentication == null || !authentication.isAuthenticated()) {
+            return ResponseEntity.status(401).body(Map.of("error", "User not authenticated"));
+        }
+
+        Page<?> emptyPage = new PageImpl<>(List.of(), PageRequest.of(page, size), 0);
+        return ResponseEntity.ok(emptyPage);
+    }
+
+    @Operation(
+            summary = "Cancel reservation (stub)",
+            description = "Cancels a reservation. Currently returns success without effect.")
+    @ApiResponses(
+            value = {
+                @ApiResponse(responseCode = "200", description = "Reservation cancelled", content = @Content(schema = @Schema(implementation = Map.class))),
+                @ApiResponse(responseCode = "401", description = "User not authenticated", content = @Content(schema = @Schema(implementation = Map.class)))
+            })
+    @DeleteMapping("/{reservationId}")
+    public ResponseEntity<Map<String, String>> cancelReservation(
+            Authentication authentication,
+            @PathVariable Long reservationId) {
+        if (authentication == null || !authentication.isAuthenticated()) {
+            return ResponseEntity.status(401).body(Map.of("error", "User not authenticated"));
+        }
+
+        // TODO: Replace with real cancellation logic once implemented
+        return ResponseEntity.ok(Map.of("message", "Reservation cancelled (stub)"));
+    }
+}


### PR DESCRIPTION
Fix #63 

The issue stemmed from frontend routes attempting to access non-existent backend URLs, resulting in 404 errors. These errors were then converted to 500 responses by Spring's global handler, causing frontend crashes when attempting to parse the unexpected payloads.

To resolve this, stub endpoints were introduced on the backend:

*   In `BorrowController`, a new `GET /api/v1/borrow/user` endpoint was added.
*   In `FeeController`, a new `GET /api/v1/fees/user` endpoint was added.
*   New `FavoritesController` was created with `GET /api/v1/favorites/user`, `POST /api/v1/favorites`, and `DELETE /api/v1/favorites/{id}`.
*   New `ReservationsController` was created with `GET /api/v1/reservations/user` and `DELETE /api/v1/reservations/{id}`.

All new endpoints return a Spring `PageImpl` object with an empty list as its content, ensuring the frontend receives the expected `{ content: [] }` JSON structure. They also return a 401 status for unauthenticated requests.

No frontend changes were required, as the new stub endpoints now provide the expected URL paths and response shapes, allowing pages like Borrowing, Fees, Reservations, and Favorites to load without crashing and correctly display empty states. These backend stubs are temporary, designed to facilitate frontend development until full feature implementations are available.