### PR TITLE
Fix bug related to deprecated API

### DIFF
--- a/backend/src/main/java/com/aaron212/onlinelibrarymanagement/backend/controller/IndexCategoryController.java
+++ b/backend/src/main/java/com/aaron212/onlinelibrarymanagement/backend/controller/IndexCategoryController.java
@@ -10,7 +10,7 @@ import java.util.List;
 import java.util.Optional;
 
 @RestController
-@RequestMapping("/api/categories")
+@RequestMapping("/api/v1/categories")
 @CrossOrigin(origins = "http://localhost:5173")
 public class IndexCategoryController {
 

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -52,6 +52,7 @@
     "vite": "^6.2.4",
     "vite-plugin-vue-devtools": "^7.7.2",
     "vitest": "^3.1.1",
-    "vue-tsc": "^2.2.8"
+    "vue-tsc": "^2.2.8",
+    "@vue/typescript-plugin": "^2.0.4"
   }
 }

--- a/frontend/src/main.ts
+++ b/frontend/src/main.ts
@@ -11,7 +11,9 @@ import { useAuthStore } from './stores/auth'
 const app = createApp(App)
 const pinia = createPinia()
 const i18n = createI18n({
-  // something vue-i18n options here ...
+  // Disable legacy API mode to use Composition API
+  legacy: false,
+  // You can add other i18n options here (locale, messages, etc.)
 })
 
 app.use(i18n)

--- a/frontend/src/shims-vue.d.ts
+++ b/frontend/src/shims-vue.d.ts
@@ -1,0 +1,6 @@
+declare module '*.vue' {
+  import { DefineComponent } from 'vue'
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const component: DefineComponent<Record<string, unknown>, Record<string, unknown>, any>
+  export default component
+}

--- a/frontend/src/views/AdminDashboardView.vue
+++ b/frontend/src/views/AdminDashboardView.vue
@@ -254,7 +254,9 @@ onMounted(() => {
             </div>
           </CardHeader>
           <CardContent>
-            <div class="text-2xl font-bold">{{ card.value.toLocaleString() }}</div>
+            <div class="text-2xl font-bold">
+              {{ typeof card.value === 'number' ? card.value.toLocaleString() : (card.value ?? '-') }}
+            </div>
             <p class="text-xs text-muted-foreground">{{ card.description }}</p>
           </CardContent>
         </Card>
@@ -311,9 +313,9 @@ onMounted(() => {
                 @click="router.push(`/books/${book.id}`)"
               >
                 <div class="flex-1 min-w-0">
-                  <p class="text-sm font-medium truncate">{{ book.title }}</p>
+                  <p class="text-sm font-medium truncate">{{ book.title || 'Unknown' }}</p>
                   <p class="text-xs text-muted-foreground truncate">
-                    {{ book.authors.map((a) => a.name).join(', ') }}
+                    {{ Array.isArray(book.authors) ? book.authors.map((a) => a.name).join(', ') : 'Unknown author' }}
                   </p>
                 </div>
                 <div class="flex flex-col items-end gap-1">
@@ -352,9 +354,12 @@ onMounted(() => {
                 class="flex items-center space-x-3 p-2 rounded-lg hover:bg-muted/50"
               >
                 <div class="flex-1 min-w-0">
-                  <p class="text-sm font-medium truncate">{{ borrow.bookCopy.book.title }}</p>
+                  <p class="text-sm font-medium truncate">
+                    {{ borrow.bookCopy?.book?.title || 'Unknown book' }}
+                  </p>
                   <p class="text-xs text-muted-foreground">
-                    User: {{ borrow.user.username }} • Due: {{ formatDate(borrow.dueDate) }}
+                    User: {{ borrow.user?.username || 'Unknown user' }} •
+                    Due: {{ borrow.dueDate ? formatDate(borrow.dueDate) : 'N/A' }}
                   </p>
                 </div>
                 <Badge :variant="getBorrowStatusBadge(borrow).variant" size="sm">

--- a/frontend/tsconfig.app.json
+++ b/frontend/tsconfig.app.json
@@ -25,5 +25,11 @@
         "./src/*"
       ]
     }
-  }
+  },
+  "plugins": [
+    {
+      "name": "@vue/typescript-plugin",
+      "templateInterpolationService": true
+    }
+  ]
 }


### PR DESCRIPTION
Fix #66 

Key fixes applied to resolve runtime errors and improve developer experience:

*   **Backend API Path Alignment:**
    *   The `@RequestMapping` in `backend/src/main/java/com/aaron212/onlinelibrarymanagement/backend/controller/IndexCategoryController.java` was updated from `/api/categories` to `/api/v1/categories`. This change aligns the backend endpoint with the frontend client's expected path, resolving the 500 server error for category data.

*   **Dashboard Data Robustness:**
    *   In `frontend/src/views/AdminDashboardView.vue`, comprehensive null and undefined checks were implemented. Optional chaining (`%3F.`), nullish coalescing (`%3F%3F`), and `Array.isArray` checks were added to data access points (e.g., `card.value`, `book.authors`, `borrow.bookCopy%3F.book%3F.title`), preventing "Cannot read properties of undefined" errors during rendering.

*   **Vue-i18n Deprecation Warning:**
    *   The Vue-i18n instance in `frontend/src/main.ts` was configured with `legacy: false` to enable Composition API mode, suppressing the deprecation warning.

*   **TypeScript Vue SFC Recognition:**
    *   The `@vue/typescript-plugin` was added to `devDependencies` in `frontend/package.json` and registered in `frontend/tsconfig.app.json`.
    *   A new type declaration file, `frontend/src/shims-vue.d.ts`, was created to declare `*.vue` modules, resolving "module not found" TypeScript errors for Vue Single File Components.