### PR TITLE
Implement add notice functionality with validation

### DIFF
--- a/backend/src/main/java/com/aaron212/onlinelibrarymanagement/backend/controller/NoticeController.java
+++ b/backend/src/main/java/com/aaron212/onlinelibrarymanagement/backend/controller/NoticeController.java
@@ -87,6 +87,25 @@ public class NoticeController {
         return ResponseEntity.ok(notices);
     }
 
+    @Operation(
+            summary = "Get all notices for admin",
+            description = "Retrieves a paginated list of all notices including unpublished ones (admin only)",
+            security = @SecurityRequirement(name = "Bearer Authentication"))
+    @ApiResponses(
+            value = {
+                @ApiResponse(
+                        responseCode = "200",
+                        description = "Notices retrieved successfully",
+                        content = @Content(schema = @Schema(implementation = Page.class)))
+            })
+    @PreAuthorize("hasRole('ADMIN')")
+    @GetMapping("/admin/all")
+    public ResponseEntity<Page<NoticeResponseDto>> getAllNoticesForAdmin(
+            @Parameter(description = "Pagination parameters") @ParameterObject Pageable pageable) {
+        Page<NoticeResponseDto> notices = noticeService.getAllNoticesForAdmin(pageable);
+        return ResponseEntity.ok(notices);
+    }
+
     @Operation(summary = "Get active notices", description = "Retrieves a paginated list of active (non-expired) notices")
     @ApiResponses(
             value = {

--- a/backend/src/main/java/com/aaron212/onlinelibrarymanagement/backend/controller/NoticeController.java
+++ b/backend/src/main/java/com/aaron212/onlinelibrarymanagement/backend/controller/NoticeController.java
@@ -160,11 +160,21 @@ public class NoticeController {
             })
     @GetMapping("/{id}")
     public ResponseEntity<?> getNoticeById(
-            @Parameter(description = "Notice ID", required = true, example = "1") @PathVariable @Positive Long id) {
-        Optional<NoticeResponseDto> notice = noticeService.getNoticeById(id);
-        if (notice.isPresent()) {
-            return ResponseEntity.ok(notice.get());
-        } else {
+            @Parameter(description = "Notice ID", required = true, example = "1") @PathVariable @Positive Long id,
+            Authentication authentication) {
+        try {
+            // Get username if authenticated, otherwise use null (will be treated as non-admin)
+            String username = (authentication != null && authentication.isAuthenticated()) 
+                ? authentication.getName() 
+                : null;
+            
+            Optional<NoticeResponseDto> notice = noticeService.getNoticeById(id, username);
+            if (notice.isPresent()) {
+                return ResponseEntity.ok(notice.get());
+            } else {
+                return ResponseEntity.status(HttpStatus.NOT_FOUND).body(Map.of("error", "Notice not found"));
+            }
+        } catch (RuntimeException e) {
             return ResponseEntity.status(HttpStatus.NOT_FOUND).body(Map.of("error", "Notice not found"));
         }
     }

--- a/backend/src/main/java/com/aaron212/onlinelibrarymanagement/backend/repository/NoticeRepository.java
+++ b/backend/src/main/java/com/aaron212/onlinelibrarymanagement/backend/repository/NoticeRepository.java
@@ -17,14 +17,17 @@ public interface NoticeRepository extends JpaRepository<Notice, Long> {
     
     Page<Notice> findByCreatorUser(User creatorUser, Pageable pageable);
     
-    @Query("SELECT n FROM Notice n WHERE n.status = :status AND (n.expireTime IS NULL OR n.expireTime > :currentTime) ORDER BY n.status DESC, n.publishTime DESC")
+    @Query("SELECT n FROM Notice n WHERE n.status = :status AND n.publishTime <= :currentTime AND (n.expireTime IS NULL OR n.expireTime > :currentTime) ORDER BY n.status DESC, n.publishTime DESC")
     Page<Notice> findActiveNoticesByStatus(@Param("status") Notice.Status status, @Param("currentTime") LocalDateTime currentTime, Pageable pageable);
     
-    @Query("SELECT n FROM Notice n WHERE (n.expireTime IS NULL OR n.expireTime > :currentTime) ORDER BY n.status DESC, n.publishTime DESC")
+    @Query("SELECT n FROM Notice n WHERE n.publishTime <= :currentTime AND (n.expireTime IS NULL OR n.expireTime > :currentTime) ORDER BY n.status DESC, n.publishTime DESC")
     Page<Notice> findActiveNotices(@Param("currentTime") LocalDateTime currentTime, Pageable pageable);
     
-    @Query("SELECT n FROM Notice n WHERE n.title LIKE %:keyword% OR n.content LIKE %:keyword%")
-    Page<Notice> searchByKeyword(@Param("keyword") String keyword, Pageable pageable);
+    @Query("SELECT n FROM Notice n WHERE (n.title LIKE %:keyword% OR n.content LIKE %:keyword%) AND n.publishTime <= :currentTime AND (n.expireTime IS NULL OR n.expireTime > :currentTime)")
+    Page<Notice> searchByKeyword(@Param("keyword") String keyword, @Param("currentTime") LocalDateTime currentTime, Pageable pageable);
+    
+    @Query("SELECT n FROM Notice n WHERE n.publishTime <= :currentTime AND (n.expireTime IS NULL OR n.expireTime > :currentTime)")
+    Page<Notice> findPublishedNotices(@Param("currentTime") LocalDateTime currentTime, Pageable pageable);
     
     List<Notice> findByExpireTimeBefore(LocalDateTime expireTime);
 } 

--- a/backend/src/main/java/com/aaron212/onlinelibrarymanagement/backend/service/NoticeService.java
+++ b/backend/src/main/java/com/aaron212/onlinelibrarymanagement/backend/service/NoticeService.java
@@ -48,6 +48,14 @@ public class NoticeService {
 
     @Transactional(readOnly = true)
     public Page<NoticeResponseDto> getAllNotices(Pageable pageable) {
+        // For getAllNotices, we should only return published notices
+        LocalDateTime currentTime = LocalDateTime.now();
+        return noticeRepository.findPublishedNotices(currentTime, pageable).map(this::mapToResponseDto);
+    }
+
+    @Transactional(readOnly = true)
+    public Page<NoticeResponseDto> getAllNoticesForAdmin(Pageable pageable) {
+        // For admin, return all notices including unpublished ones
         return noticeRepository.findAll(pageable).map(this::mapToResponseDto);
     }
 
@@ -66,7 +74,9 @@ public class NoticeService {
 
     @Transactional(readOnly = true)
     public Optional<NoticeResponseDto> getNoticeById(Long id) {
-        return noticeRepository.findById(id).map(this::mapToResponseDto);
+        return noticeRepository.findById(id)
+                .filter(notice -> notice.getPublishTime().isBefore(LocalDateTime.now()) || notice.getPublishTime().isEqual(LocalDateTime.now()))
+                .map(this::mapToResponseDto);
     }
 
     @Transactional(readOnly = true)
@@ -78,7 +88,8 @@ public class NoticeService {
 
     @Transactional(readOnly = true)
     public Page<NoticeResponseDto> searchNotices(String keyword, Pageable pageable) {
-        return noticeRepository.searchByKeyword(keyword, pageable).map(this::mapToResponseDto);
+        LocalDateTime currentTime = LocalDateTime.now();
+        return noticeRepository.searchByKeyword(keyword, currentTime, pageable).map(this::mapToResponseDto);
     }
 
     public NoticeResponseDto updateNotice(Long id, NoticeUpdateDto noticeUpdateDto, String updaterUsername) {

--- a/frontend/src/lib/api/services/notices.ts
+++ b/frontend/src/lib/api/services/notices.ts
@@ -14,6 +14,10 @@ export class NoticesService {
     return apiClient.get<PagedResponse<Notice>>(this.basePath, params)
   }
 
+  async getAllForAdmin(params?: { page?: number; size?: number }): Promise<PagedResponse<Notice>> {
+    return apiClient.get<PagedResponse<Notice>>(`${this.basePath}/admin/all`, params)
+  }
+
   async getById(id: number): Promise<Notice> {
     return apiClient.get<Notice>(`${this.basePath}/${id}`)
   }

--- a/frontend/src/lib/api/types.ts
+++ b/frontend/src/lib/api/types.ts
@@ -151,18 +151,28 @@ export interface Notice {
   id: number
   title: string
   content: string
-  publishDate: string
-  lastUpdateTime?: string
+  creatorUsername: string
+  publishTime: string
+  expireTime?: string
+  status: number
+  createTime: string
+  updateTime: string
 }
 
 export interface NoticeCreateDto {
   title: string
   content: string
+  publishTime: string
+  expireTime?: string
+  status: number
 }
 
 export interface NoticeUpdateDto {
   title?: string
   content?: string
+  publishTime?: string
+  expireTime?: string
+  status?: number
 }
 
 // Fee types

--- a/frontend/src/views/AdminDashboardView.vue
+++ b/frontend/src/views/AdminDashboardView.vue
@@ -408,7 +408,7 @@ onMounted(() => {
                       {{ notice.content || 'No content' }}
                     </p>
                     <p class="text-xs text-muted-foreground mt-2">
-                      Published: {{ notice.publishDate ? formatDate(notice.publishDate) : 'N/A' }}
+                      Published: {{ notice.publishTime ? formatDate(notice.publishTime) : 'N/A' }}
                     </p>
                   </div>
                   <Button

--- a/frontend/src/views/DashboardView.vue
+++ b/frontend/src/views/DashboardView.vue
@@ -397,7 +397,7 @@ onMounted(() => {
                   {{ notice.content }}
                 </p>
                 <p class="text-xs text-muted-foreground mt-2">
-                  {{ formatDate(notice.publishDate) }}
+                  {{ formatDate(notice.publishTime) }}
                 </p>
               </div>
             </div>

--- a/frontend/src/views/HomeView.vue
+++ b/frontend/src/views/HomeView.vue
@@ -303,7 +303,7 @@ onMounted(() => {
           >
             <CardHeader>
               <CardTitle class="line-clamp-2">{{ notice.title }}</CardTitle>
-              <CardDescription>{{ formatDate(notice.publishDate) }}</CardDescription>
+              <CardDescription>{{ formatDate(notice.publishTime) }}</CardDescription>
             </CardHeader>
             <CardContent>
               <p class="text-sm text-muted-foreground line-clamp-3">{{ notice.content }}</p>

--- a/frontend/src/views/NoticesView.vue
+++ b/frontend/src/views/NoticesView.vue
@@ -137,13 +137,29 @@ const isRecent = (dateString: string) => {
   return days <= 7
 }
 
+// Helper function to format date for datetime-local input
+const formatDateForInput = (date: Date) => {
+  const year = date.getFullYear()
+  const month = String(date.getMonth() + 1).padStart(2, '0')
+  const day = String(date.getDate()).padStart(2, '0')
+  const hours = String(date.getHours()).padStart(2, '0')
+  const minutes = String(date.getMinutes()).padStart(2, '0')
+  return `${year}-${month}-${day}T${hours}:${minutes}`
+}
+
+// Helper function to convert UTC date string to local datetime format
+const formatUTCDateForInput = (utcDateString: string) => {
+  const date = new Date(utcDateString)
+  return formatDateForInput(date)
+}
+
 const openAddDialog = () => {
   const now = new Date()
   const publishTime = new Date(now.getTime() + 5 * 60000) // Default to 5 minutes from now
   noticeForm.value = { 
     title: '', 
     content: '',
-    publishTime: publishTime.toISOString().slice(0, 16), // Format for datetime-local input
+    publishTime: formatDateForInput(publishTime), // Use local time directly
     expireTime: '',
     status: 1
   }
@@ -152,8 +168,8 @@ const openAddDialog = () => {
 
 const openEditDialog = (notice: Notice) => {
   editingNotice.value = notice
-  const publishTime = new Date(notice.publishTime).toISOString().slice(0, 16)
-  const expireTime = notice.expireTime ? new Date(notice.expireTime).toISOString().slice(0, 16) : ''
+  const publishTime = formatUTCDateForInput(notice.publishTime)
+  const expireTime = notice.expireTime ? formatUTCDateForInput(notice.expireTime) : ''
   
   noticeForm.value = {
     title: notice.title,

--- a/frontend/src/views/NoticesView.vue
+++ b/frontend/src/views/NoticesView.vue
@@ -441,7 +441,7 @@ onMounted(() => {
             <Label for="add-status">Status *</Label>
             <select
               id="add-status"
-              v-model="noticeForm.status"
+              v-model.number="noticeForm.status"
               class="w-full p-3 border rounded-md bg-background"
               required
             >
@@ -515,7 +515,7 @@ onMounted(() => {
             <Label for="edit-status">Status *</Label>
             <select
               id="edit-status"
-              v-model="noticeForm.status"
+              v-model.number="noticeForm.status"
               class="w-full p-3 border rounded-md bg-background"
               required
             >

--- a/frontend/src/views/NoticesView.vue
+++ b/frontend/src/views/NoticesView.vue
@@ -22,6 +22,7 @@ import {
   Plus,
   Search,
   Trash2,
+  Clock,
 } from 'lucide-vue-next'
 import { noticesService } from '@/lib/api'
 import type { Notice, PagedResponse } from '@/lib/api/types'
@@ -48,12 +49,14 @@ const isSubmitting = ref(false)
 const noticeForm = ref({
   title: '',
   content: '',
+  publishTime: '',
+  expireTime: '',
+  status: 1,
 })
 
 // Computed
 const isAdmin = computed(() => {
-  // This should be replaced with actual role checking when user roles are available
-  return authStore.isAuthenticated
+  return authStore.isAdmin()
 })
 
 const filteredNotices = computed(() => {
@@ -71,10 +74,22 @@ const filteredNotices = computed(() => {
 const loadNotices = async () => {
   try {
     isLoading.value = true
-    const response: PagedResponse<Notice> = await noticesService.getAll({
-      page: currentPage.value,
-      size: pageSize.value,
-    })
+    let response: PagedResponse<Notice>
+    
+    if (isAdmin.value) {
+      // Admin can see all notices including unpublished ones
+      response = await noticesService.getAllForAdmin({
+        page: currentPage.value,
+        size: pageSize.value,
+      })
+    } else {
+      // Regular users only see published notices
+      response = await noticesService.getAll({
+        page: currentPage.value,
+        size: pageSize.value,
+      })
+    }
+    
     notices.value = response.content
     totalPages.value = response.totalPages
     totalElements.value = response.totalElements
@@ -123,15 +138,29 @@ const isRecent = (dateString: string) => {
 }
 
 const openAddDialog = () => {
-  noticeForm.value = { title: '', content: '' }
+  const now = new Date()
+  const publishTime = new Date(now.getTime() + 5 * 60000) // Default to 5 minutes from now
+  noticeForm.value = { 
+    title: '', 
+    content: '',
+    publishTime: publishTime.toISOString().slice(0, 16), // Format for datetime-local input
+    expireTime: '',
+    status: 1
+  }
   showAddDialog.value = true
 }
 
 const openEditDialog = (notice: Notice) => {
   editingNotice.value = notice
+  const publishTime = new Date(notice.publishTime).toISOString().slice(0, 16)
+  const expireTime = notice.expireTime ? new Date(notice.expireTime).toISOString().slice(0, 16) : ''
+  
   noticeForm.value = {
     title: notice.title,
     content: notice.content,
+    publishTime: publishTime,
+    expireTime: expireTime,
+    status: notice.status,
   }
   showEditDialog.value = true
 }
@@ -140,12 +169,18 @@ const closeDialogs = () => {
   showAddDialog.value = false
   showEditDialog.value = false
   editingNotice.value = null
-  noticeForm.value = { title: '', content: '' }
+  noticeForm.value = { 
+    title: '', 
+    content: '',
+    publishTime: '',
+    expireTime: '',
+    status: 1
+  }
 }
 
 const handleCreateNotice = async () => {
-  if (!noticeForm.value.title.trim() || !noticeForm.value.content.trim()) {
-    toast.error('Please fill in all fields')
+  if (!noticeForm.value.title.trim() || !noticeForm.value.content.trim() || !noticeForm.value.publishTime) {
+    toast.error('Please fill in all required fields')
     return
   }
 
@@ -154,6 +189,9 @@ const handleCreateNotice = async () => {
     await noticesService.create({
       title: noticeForm.value.title.trim(),
       content: noticeForm.value.content.trim(),
+      publishTime: new Date(noticeForm.value.publishTime).toISOString(),
+      expireTime: noticeForm.value.expireTime ? new Date(noticeForm.value.expireTime).toISOString() : undefined,
+      status: noticeForm.value.status,
     })
 
     toast.success('Notice created successfully!')
@@ -168,8 +206,8 @@ const handleCreateNotice = async () => {
 }
 
 const handleUpdateNotice = async () => {
-  if (!editingNotice.value || !noticeForm.value.title.trim() || !noticeForm.value.content.trim()) {
-    toast.error('Please fill in all fields')
+  if (!editingNotice.value || !noticeForm.value.title.trim() || !noticeForm.value.content.trim() || !noticeForm.value.publishTime) {
+    toast.error('Please fill in all required fields')
     return
   }
 
@@ -178,6 +216,9 @@ const handleUpdateNotice = async () => {
     await noticesService.update(editingNotice.value.id, {
       title: noticeForm.value.title.trim(),
       content: noticeForm.value.content.trim(),
+      publishTime: new Date(noticeForm.value.publishTime).toISOString(),
+      expireTime: noticeForm.value.expireTime ? new Date(noticeForm.value.expireTime).toISOString() : undefined,
+      status: noticeForm.value.status,
     })
 
     toast.success('Notice updated successfully!')
@@ -279,18 +320,21 @@ onMounted(() => {
               <div class="flex-1">
                 <div class="flex items-center gap-2 mb-2">
                   <CardTitle class="text-lg">{{ notice.title }}</CardTitle>
-                  <Badge v-if="isRecent(notice.publishDate)" variant="secondary" class="text-xs">
+                  <Badge v-if="isRecent(notice.publishTime)" variant="secondary" class="text-xs">
                     New
                   </Badge>
                 </div>
                 <div class="flex items-center gap-2 text-sm text-muted-foreground">
                   <Calendar class="h-4 w-4" />
-                  <span>{{ getTimeSince(notice.publishDate) }}</span>
+                  <span>{{ getTimeSince(notice.publishTime) }}</span>
                   <span
-                    v-if="notice.lastUpdateTime && notice.lastUpdateTime !== notice.publishDate"
+                    v-if="notice.updateTime && notice.updateTime !== notice.publishTime"
                   >
-                    • Updated {{ getTimeSince(notice.lastUpdateTime) }}
+                    • Updated {{ getTimeSince(notice.updateTime) }}
                   </span>
+                  <Badge v-if="notice.status === 2" variant="outline" class="text-xs ml-2">
+                    Pinned
+                  </Badge>
                 </div>
               </div>
 
@@ -372,6 +416,40 @@ onMounted(() => {
             />
           </div>
 
+          <div class="grid grid-cols-1 md:grid-cols-2 gap-4">
+            <div class="space-y-2">
+              <Label for="add-publish-time">Publish Time *</Label>
+              <Input
+                id="add-publish-time"
+                v-model="noticeForm.publishTime"
+                type="datetime-local"
+                required
+              />
+            </div>
+
+            <div class="space-y-2">
+              <Label for="add-expire-time">Expire Time (optional)</Label>
+              <Input
+                id="add-expire-time"
+                v-model="noticeForm.expireTime"
+                type="datetime-local"
+              />
+            </div>
+          </div>
+
+          <div class="space-y-2">
+            <Label for="add-status">Status *</Label>
+            <select
+              id="add-status"
+              v-model="noticeForm.status"
+              class="w-full p-3 border rounded-md bg-background"
+              required
+            >
+              <option value="1">Show</option>
+              <option value="2">Pinned</option>
+            </select>
+          </div>
+
           <div class="flex justify-end gap-2">
             <Button type="button" variant="outline" @click="closeDialogs"> Cancel </Button>
             <Button type="submit" :disabled="isSubmitting">
@@ -412,6 +490,40 @@ onMounted(() => {
             />
           </div>
 
+          <div class="grid grid-cols-1 md:grid-cols-2 gap-4">
+            <div class="space-y-2">
+              <Label for="edit-publish-time">Publish Time *</Label>
+              <Input
+                id="edit-publish-time"
+                v-model="noticeForm.publishTime"
+                type="datetime-local"
+                required
+              />
+            </div>
+
+            <div class="space-y-2">
+              <Label for="edit-expire-time">Expire Time (optional)</Label>
+              <Input
+                id="edit-expire-time"
+                v-model="noticeForm.expireTime"
+                type="datetime-local"
+              />
+            </div>
+          </div>
+
+          <div class="space-y-2">
+            <Label for="edit-status">Status *</Label>
+            <select
+              id="edit-status"
+              v-model="noticeForm.status"
+              class="w-full p-3 border rounded-md bg-background"
+              required
+            >
+              <option value="1">Show</option>
+              <option value="2">Pinned</option>
+            </select>
+          </div>
+
           <div class="flex justify-end gap-2">
             <Button type="button" variant="outline" @click="closeDialogs"> Cancel </Button>
             <Button type="submit" :disabled="isSubmitting">
@@ -430,13 +542,13 @@ onMounted(() => {
   margin: 0 auto;
 }
 
-textarea {
+textarea, select {
   background: hsl(var(--background));
   border: 1px solid hsl(var(--border));
   color: hsl(var(--foreground));
 }
 
-textarea:focus {
+textarea:focus, select:focus {
   outline: none;
   border-color: hsl(var(--ring));
   box-shadow: 0 0 0 2px hsl(var(--ring) / 0.2);


### PR DESCRIPTION
Fix #71

The session addressed missing `publishTime` and `status` configurations in the frontend and implemented backend filtering for notice visibility.

In the frontend:
*   `frontend/src/lib/api/types.ts` was updated to include `publishTime`, `expireTime`, and `status` in `NoticeCreateDto` and `NoticeUpdateDto`, and to align the `Notice` interface with backend fields.
*   `frontend/src/views/NoticesView.vue` was modified to add `datetime-local` inputs for `publishTime` (defaulting to 5 mins from now) and `expireTime`, and a dropdown for `status` in both add and edit forms.
*   Form submission logic was updated to send these new fields, and validation was enhanced.
*   Notice loading was adjusted to use `noticesService.getAllForAdmin()` for administrators, ensuring they see all notices, while regular users continue to use `noticesService.getAll()`.

In the backend:
*   `backend/src/main/java/com/aaron212/onlinelibrarymanagement/backend/repository/NoticeRepository.java` queries (`findActiveNoticesByStatus`, `findActiveNotices`, `searchByKeyword`) were updated to include `n.publishTime <= :currentTime`. A new `findPublishedNotices` query was added.
*   `backend/src/main/java/com/aaron212/onlinelibrarymanagement/backend/service/NoticeService.java` now uses `findPublishedNotices` for `getAllNotices` and includes `publishTime` checks for `getNoticeById` and `searchNotices`. A new `getAllNoticesForAdmin` method was introduced.
*   `backend/src/main/java/com/aaron212/onlinelibrarymanagement/backend/controller/NoticeController.java` gained an admin-only endpoint `/api/v1/notices/admin/all` to expose all notices.

These changes resolve the `NotNull` validation errors and ensure notices are only visible to users after their `publishTime`, while providing administrators full visibility.