### PR TITLE
Fix server error for book copies

### DIFF
--- a/backend/src/main/java/com/aaron212/onlinelibrarymanagement/backend/controller/BookController.java
+++ b/backend/src/main/java/com/aaron212/onlinelibrarymanagement/backend/controller/BookController.java
@@ -7,9 +7,10 @@ import com.aaron212.onlinelibrarymanagement.backend.dto.BookSummaryDto;
 import com.aaron212.onlinelibrarymanagement.backend.dto.BookUpdateDto;
 import com.aaron212.onlinelibrarymanagement.backend.dto.IndexCategoryDto;
 import com.aaron212.onlinelibrarymanagement.backend.dto.PublisherDto;
+import com.aaron212.onlinelibrarymanagement.backend.dto.BookCopyDto;
 import com.aaron212.onlinelibrarymanagement.backend.model.Book;
-import com.aaron212.onlinelibrarymanagement.backend.model.BookCopy;
 import com.aaron212.onlinelibrarymanagement.backend.service.BookService;
+import com.aaron212.onlinelibrarymanagement.backend.service.BookCopyService;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.media.Content;
@@ -43,9 +44,11 @@ import static org.springframework.data.web.config.EnableSpringDataWebSupport.Pag
 public class BookController {
 
     private final BookService bookService;
+    private final BookCopyService bookCopyService;
 
-    public BookController(BookService bookService) {
+    public BookController(BookService bookService, BookCopyService bookCopyService) {
         this.bookService = bookService;
+        this.bookCopyService = bookCopyService;
     }
 
     @Operation(
@@ -265,7 +268,7 @@ public class BookController {
     public ResponseEntity<?> getBookCopies(
             @Parameter(description = "Book ID", required = true, example = "1") @PathVariable @Positive Long id) {
         try {
-            List<BookCopy> copies = bookService.getBookCopies(id);
+            List<BookCopyDto> copies = bookCopyService.getCopiesByBookId(id);
             return ResponseEntity.ok(copies);
         } catch (RuntimeException e) {
             return ResponseEntity.status(HttpStatus.NOT_FOUND).body(Map.of("error", "Book not found"));


### PR DESCRIPTION
Fix #86

A 500 Internal Server Error occurred when fetching book copies due to the backend endpoint returning raw `BookCopy` entities. These entities, having a bidirectional relationship with `Book`, caused serialization issues with lazy-loaded collections.

To resolve this, the backend was updated:
*   In `backend/src/main/java/com/aaron212/onlinelibrarymanagement/backend/controller/BookController.java`:
    *   `BookCopyDto` and `BookCopyService` were imported.
    *   `BookCopyService` was injected into the `BookController`.
    *   The `getBookCopies` handler was refactored to use `bookCopyService.getCopiesByBookId(id)` and return a `List<BookCopyDto>`.

This change ensures that a flat, serialization-safe data transfer object (DTO) is returned, preventing the circular reference and lazy-loading issues that caused the 500 error. The frontend's existing `BookCopy` interface is compatible with the new DTO shape, requiring no frontend modifications.