### PR TITLE
Fix overlapping book cards in view

### DIFF
--- a/frontend/src/components/BookCard.vue
+++ b/frontend/src/components/BookCard.vue
@@ -41,7 +41,7 @@ const availabilityText = computed(() => {
 </script>
 
 <template>
-  <Card class="w-64 h-auto flex flex-col hover:shadow-lg transition-shadow p-0">
+  <Card class="w-full h-auto flex flex-col hover:shadow-lg transition-shadow p-0">
     <CardHeader class="p-0">
       <div
         class="aspect-[3/4] w-full bg-muted flex items-center justify-center rounded-t-lg overflow-hidden relative"

--- a/frontend/src/views/BooksView.vue
+++ b/frontend/src/views/BooksView.vue
@@ -329,7 +329,7 @@ onMounted(() => {
 
     <div
       v-else
-      class="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 lg:grid-cols-4 xl:grid-cols-6 gap-4"
+      class="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 lg:grid-cols-4 xl:grid-cols-5 2xl:grid-cols-6 gap-6"
     >
       <div
         v-for="book in books"


### PR DESCRIPTION
The overlapping book cards issue was resolved by adjusting sizing and layout properties.

In `frontend/src/components/BookCard.vue`, the fixed width class `w-64` was replaced with `w-full`. This allows the `BookCard` component to dynamically adjust its width based on the parent container, enabling the grid layout to properly control card sizing.

Concurrently, the grid layout in `frontend/src/views/BooksView.vue` was optimized for better responsiveness and spacing. The `gap-4` class was updated to `gap-6` to increase spacing between cards. The column definitions were adjusted from `xl:grid-cols-6` to `xl:grid-cols-5` and `2xl:grid-cols-6`.

These changes ensure that cards fit appropriately within their grid cells across various screen sizes, preventing overcrowding and resolving the overlap that occurred when the `BookCard`'s fixed width conflicted with the `BooksView` grid's attempt to fit too many columns.