### PR TITLE
Improve error message for book borrowing

### DIFF
--- a/backend/src/main/java/com/aaron212/onlinelibrarymanagement/backend/service/BorrowService.java
+++ b/backend/src/main/java/com/aaron212/onlinelibrarymanagement/backend/service/BorrowService.java
@@ -90,7 +90,7 @@ public class BorrowService {
         boolean userAlreadyBorrowed = borrowRepository.existsByUserIdAndCopyBookIdAndStatus(
                 userId, copy.getBook().getId(), Borrow.Status.BORROWED);
         if (userAlreadyBorrowed) {
-            throw new BusinessLogicException("您已借阅此书，不能重复借阅");
+            throw new BusinessLogicException("You have already borrowed this book. Please return the current copy before borrowing another.");
         }
 
         // Create borrow record

--- a/frontend/src/lib/api/client.ts
+++ b/frontend/src/lib/api/client.ts
@@ -75,7 +75,8 @@ class ApiClient {
 
       try {
         const errorData = await response.json()
-        errorMessage = errorData.error || errorData.message || errorMessage
+        // Prefer the detailed server-provided message if available, otherwise fall back to the generic error field
+        errorMessage = errorData.message || errorData.error || errorMessage
       } catch {
         // If we can't parse JSON, use the response text
         try {

--- a/frontend/src/views/BookDetailView.vue
+++ b/frontend/src/views/BookDetailView.vue
@@ -119,7 +119,9 @@ const handleBorrow = async () => {
     await loadBook()
   } catch (error) {
     console.error('Error borrowing book:', error)
-    toast.error('Failed to borrow book. Please try again.')
+    // Use the detailed error message from the API if available to give users clearer feedback
+    const errMsg = (error as any)?.message || 'Failed to borrow book'
+    toast.error(errMsg)
   } finally {
     isBorrowing.value = false
   }


### PR DESCRIPTION
The error message displayed when a user attempts to borrow a book they already possess has been clarified.

*   In `backend/src/main/java/com/aaron212/onlinelibrarymanagement/backend/service/BorrowService.java`, the `BusinessLogicException` message for duplicate borrows was updated to a clear English message: "You have already borrowed this book. Please return the current copy before borrowing another."
*   `frontend/src/lib/api/client.ts` was modified to prioritize the `message` field from API error responses, ensuring that detailed server-provided error messages are used instead of generic ones.
*   The `frontend/src/views/BookDetailView.vue` component's borrow failure toast now displays the specific error message received from the backend (`err.message`) rather than a generic "Please try again."

These changes ensure that users receive a precise and actionable explanation when attempting to borrow a duplicate copy of a book.