### PR TITLE
Move favorite button to top left

### DIFF
--- a/frontend/src/components/BookCard.vue
+++ b/frontend/src/components/BookCard.vue
@@ -64,30 +64,27 @@ const handleFavoriteChanged = (isFavorite: boolean) => {
         </div>
         <div v-else class="text-sm text-muted-foreground p-4 text-center">No image available</div>
 
-        <!-- Top right badges/buttons -->
-        <div class="absolute top-2 right-2 flex flex-col gap-2">
-          <!-- Availability Badge -->
-          <div v-if="availabilityStatus">
-            <Badge :variant="availabilityStatus === 'available'
-              ? 'default'
-              : availabilityStatus === 'limited'
-                ? 'secondary'
-                : 'destructive'
-              " class="text-xs">
-              {{
-                availabilityStatus === 'available'
-                  ? 'Available'
-                  : availabilityStatus === 'limited'
-                    ? 'Limited'
-                    : 'Out of Stock'
-              }}
-            </Badge>
-          </div>
+        <!-- Top left favorite button -->
+        <div v-if="showFavoriteButton && bookId" class="absolute top-2 left-2">
+          <FavoriteButton :book-id="bookId" size="sm" variant="outline" @favorite-changed="handleFavoriteChanged" />
+        </div>
 
-          <!-- Favorite Button -->
-          <div v-if="showFavoriteButton && bookId">
-            <FavoriteButton :book-id="bookId" size="sm" variant="outline" @favorite-changed="handleFavoriteChanged" />
-          </div>
+        <!-- Top right availability badge -->
+        <div v-if="availabilityStatus" class="absolute top-2 right-2">
+          <Badge :variant="availabilityStatus === 'available'
+            ? 'default'
+            : availabilityStatus === 'limited'
+              ? 'secondary'
+              : 'destructive'
+            " class="text-xs">
+            {{
+              availabilityStatus === 'available'
+                ? 'Available'
+                : availabilityStatus === 'limited'
+                  ? 'Limited'
+                  : 'Out of Stock'
+            }}
+          </Badge>
         </div>
       </div>
     </CardHeader>


### PR DESCRIPTION
In `frontend/src/components/BookCard.vue`, the positioning of the Favorite button was adjusted.

Previously:
*   Both the Favorite button and the availability badge were contained within a single `div` element positioned at the top-right corner using `absolute top-2 right-2`.

Changes Made:
*   The `FavoriteButton` and the `Badge` components were separated into their own distinct `div` containers.
*   The `FavoriteButton`'s new container was positioned to the top-left using `absolute top-2 left-2`.
*   The `Badge` component's container retained its original `absolute top-2 right-2` positioning, keeping it in the top-right corner.
*   All conditional rendering logic, props, and styling for both components were preserved, ensuring no functional changes.

This modification allows independent positioning of the Favorite button and the availability badge within the `BookCard`.