### PR TITLE
Remove items from app sidebar

### DIFF
--- a/frontend/src/components/AppSidebar.vue
+++ b/frontend/src/components/AppSidebar.vue
@@ -67,12 +67,6 @@ const navigationItems = computed(() => [
     icon: Bell,
   },
   {
-    title: 'My Reservations',
-    url: '/reservations',
-    icon: Clock,
-    requiresAuth: true,
-  },
-  {
     title: 'Favorites',
     url: '/favorites',
     icon: Heart,
@@ -83,11 +77,6 @@ const navigationItems = computed(() => [
     url: '/billing',
     icon: CreditCard,
     requiresAuth: true,
-  },
-  {
-    title: 'Api Test',
-    url: '/api-test',
-    icon: Bell,
   },
 ])
 


### PR DESCRIPTION
The app sidebar was updated to remove two navigation items.

*   The "My Reservations" item, previously linking to `/reservations` with the `Clock` icon, was removed from the `navigationItems` array in `frontend/src/components/AppSidebar.vue`.
*   The "Api Test" item, previously linking to `/api-test` with the `Bell` icon, was also removed from the same `navigationItems` array.

These changes streamline the sidebar navigation, leaving only essential items such as Home, Dashboard, Books, Notices, Favorites, and Billing Center.