### PR TITLE
Display notices on admin dashboard

### DIFF
--- a/frontend/src/views/AdminDashboardView.vue
+++ b/frontend/src/views/AdminDashboardView.vue
@@ -170,7 +170,7 @@ const loadRecentBorrows = async () => {
 
 const loadRecentNotices = async () => {
   try {
-    const response = await noticesService.getAll({ page: 0, size: 3 })
+    const response = await noticesService.getAllForAdmin({ page: 0, size: 3 })
     recentNotices.value = response.content || []
   } catch (error) {
     console.error('Error loading recent notices:', error)


### PR DESCRIPTION
The admin dashboard was not displaying all notices, including unpublished ones, due to an incorrect API call.

*   In `frontend/src/views/AdminDashboardView.vue`, the `loadRecentNotices()` method was updated.
*   The call to `noticesService.getAll({ page: 0, size: 3 })` was changed to `noticesService.getAllForAdmin({ page: 0, size: 3 })`.
*   This change ensures the dashboard now uses the admin-specific service method, which fetches all notices (including drafts) from the `/api/v1/notices/admin/all` endpoint, rather than only public notices from `/api/v1/notices`.
*   The `NoticesView.vue` was confirmed to already handle admin roles correctly.
*   The fix allows the admin dashboard to properly display all notices.