### PR TITLE
Fix book cover display issue

### DIFF
--- a/frontend/src/views/AdminBorrowingView.vue
+++ b/frontend/src/views/AdminBorrowingView.vue
@@ -150,9 +150,39 @@ const bookCoverMap = computed(() => {
   return map
 })
 
-// Get book cover URL by ISBN
-const getBookCoverUrl = (isbn: string): string | undefined => {
-  return bookCoverMap.value.get(isbn)
+// Cache for on-demand loaded book covers
+const coverCache = ref(new Map<string, string>())
+
+// Get book cover URL by ISBN with on-demand loading
+const getBookCoverUrl = async (isbn: string): Promise<string | undefined> => {
+  // Check if we already have it in the main book map
+  if (bookCoverMap.value.has(isbn)) {
+    return bookCoverMap.value.get(isbn)
+  }
+
+  // Check if we already cached it
+  if (coverCache.value.has(isbn)) {
+    return coverCache.value.get(isbn)
+  }
+
+  // Try to find the book by ISBN and load its cover
+  try {
+    const response = await booksService.getAll({ keyword: isbn, page: 0, size: 1 })
+    const book = response.content.find(b => b.isbn === isbn)
+    if (book?.coverURL) {
+      coverCache.value.set(isbn, book.coverURL)
+      return book.coverURL
+    }
+  } catch (error) {
+    console.error('Error loading book cover for ISBN:', isbn, error)
+  }
+
+  return undefined
+}
+
+// Synchronous version for template usage (uses cached values only)
+const getBookCoverUrlSync = (isbn: string): string | undefined => {
+  return bookCoverMap.value.get(isbn) || coverCache.value.get(isbn)
 }
 
 const activeBorrows = computed(() => borrows.value.filter((borrow) => borrow.status === 'BORROWED'))
@@ -201,11 +231,29 @@ const formatDate = (dateString: string) => {
   return new Date(dateString).toLocaleDateString()
 }
 
+// Function to preload missing book covers
+const preloadMissingCovers = async (borrowList: Borrow[]) => {
+  const missingIsbns = borrowList
+    .map(borrow => borrow.isbn)
+    .filter(isbn => !bookCoverMap.value.has(isbn) && !coverCache.value.has(isbn))
+  
+  // Remove duplicates
+  const uniqueIsbns = [...new Set(missingIsbns)]
+  
+  // Load covers for missing ISBNs in parallel
+  await Promise.allSettled(
+    uniqueIsbns.map(isbn => getBookCoverUrl(isbn))
+  )
+}
+
 const loadBorrows = async () => {
   try {
     isLoading.value = true
     const allBorrows = await borrowService.adminGetAllBorrows()
     borrows.value = allBorrows
+    
+    // Preload any missing book covers
+    await preloadMissingCovers(allBorrows)
   } catch (error) {
     console.error('Error loading borrows:', error)
     toast.error('Failed to load borrowing records')
@@ -226,8 +274,20 @@ const loadUsers = async () => {
 
 const loadBooks = async () => {
   try {
-    const response = await booksService.getAll({ page: 0, size: 100 })
-    books.value = response.content
+    // Load all books to ensure we have cover URLs for all borrow records
+    let allBooks: BookType[] = []
+    let page = 0
+    const size = 100
+    let hasMore = true
+
+    while (hasMore) {
+      const response = await booksService.getAll({ page, size })
+      allBooks = [...allBooks, ...response.content]
+      hasMore = response.content.length === size && !response.last
+      page++
+    }
+
+    books.value = allBooks
   } catch (error) {
     console.error('Error loading books:', error)
     toast.error('Failed to load books')
@@ -647,8 +707,8 @@ onMounted(() => {
               <div class="flex items-start gap-4 flex-1">
                 <div class="w-16 h-20 bg-muted rounded flex items-center justify-center overflow-hidden">
                   <img
-                    v-if="getBookCoverUrl(borrow.isbn)"
-                    :src="getBookCoverUrl(borrow.isbn)"
+                    v-if="getBookCoverUrlSync(borrow.isbn)"
+                    :src="getBookCoverUrlSync(borrow.isbn)"
                     :alt="borrow.bookTitle"
                     class="w-full h-full object-cover"
                     @error="($event.target as HTMLImageElement).style.display = 'none'"

--- a/frontend/src/views/AdminBorrowingView.vue
+++ b/frontend/src/views/AdminBorrowingView.vue
@@ -167,8 +167,7 @@ const getBookCoverUrl = async (isbn: string): Promise<string | undefined> => {
 
   // Try to find the book by ISBN and load its cover
   try {
-    const response = await booksService.getAll({ keyword: isbn, page: 0, size: 1 })
-    const book = response.content.find(b => b.isbn === isbn)
+    const book = await booksService.getByIsbn(isbn)
     if (book?.coverURL) {
       coverCache.value.set(isbn, book.coverURL)
       return book.coverURL


### PR DESCRIPTION
Book covers were not displaying due to the `Borrow` interface lacking `coverURL` and an incomplete `bookCoverMap`.

Changes were made in `frontend/src/views/AdminBorrowingView.vue` to address this:

*   The `loadBooks()` function was updated to fetch *all* books, not just the first 100, ensuring comprehensive `bookCoverMap` population.
*   A `coverCache` was introduced to store on-demand fetched cover URLs.
*   The `getBookCoverUrl()` function was refactored to be `async`, checking `bookCoverMap`, then `coverCache`, and finally performing an on-demand API call if the cover is still missing.
*   A synchronous `getBookCoverUrlSync()` was added for template usage, accessing covers from `bookCoverMap` or `coverCache`.
*   A `preloadMissingCovers()` function was implemented to identify and fetch covers for ISBNs present in borrow records but missing from the initial `bookCoverMap` or `coverCache`.
*   `loadBorrows()` was updated to call `preloadMissingCovers()` after fetching borrow data.
*   The template was modified to use `getBookCoverUrlSync()` for displaying book covers.

This ensures all book covers are loaded, either initially or on-demand, and are available for display.