### PR TITLE
Fix current users count display bug

### DIFF
--- a/frontend/src/lib/api/services/statistics.ts
+++ b/frontend/src/lib/api/services/statistics.ts
@@ -1,5 +1,6 @@
 import { apiClient } from '../client'
 import type { BookStatisticsDto, LibraryStatisticsDto, TopBooksRequestDto, PagedResponse, UserAdmin } from '../types'
+import { usersService } from './users'
 
 export class StatisticsService {
   private basePath = '/statistics'
@@ -57,8 +58,13 @@ export class StatisticsService {
 
   // Helper method to get total user count (for admin dashboard)
   async getTotalUsers(): Promise<number> {
-    const response = await apiClient.get<PagedResponse<UserAdmin>>('/users/all', { page: 0, size: 1 })
-    return response.totalElements
+    try {
+      const response = await usersService.getAllUsers({ page: 0, size: 1 })
+      return response.totalElements || 0
+    } catch (error) {
+      console.error('Error fetching total users:', error)
+      return 0
+    }
   }
 }
 


### PR DESCRIPTION
The total users count displaying as "-" was addressed.

The root cause was identified in `frontend/src/lib/api/services/statistics.ts`:
*   The `getTotalUsers()` method was making a direct API call instead of utilizing `usersService.getAllUsers()`.
*   This was updated to import and use `usersService.getAllUsers()`, ensuring consistency and proper data retrieval.
*   Error handling was added to `getTotalUsers()`, returning `0` on failure to prevent `undefined` values.

Further improvements were made in `frontend/src/views/AdminDashboardView.vue` to enhance robustness:
*   Individual `.catch()` blocks were added to the promises within `Promise.all()` for `statisticsService.getUserBehaviorAnalysis()` and `statisticsService.getTotalUsers()`. This allows specific statistics to gracefully fail without affecting others.
*   Fallback values (e.g., `0` or default objects) are now returned in case of individual API call failures.
*   Type checking (`typeof ... === 'number'`) was introduced before assigning fetched values to `systemStats.value` to ensure numerical integrity.
*   A `toast.error` notification was added to inform the user if system statistics fail to load.

These changes ensure the total users count displays correctly and improve the dashboard's resilience to API errors.