### PR TITLE
Add language selector to app sidebar

### DIFF
--- a/frontend/src/components/AppSidebar.vue
+++ b/frontend/src/components/AppSidebar.vue
@@ -10,6 +10,7 @@ import {
   Gauge,
   Heart,
   Home,
+  Languages,
   Library,
   LogOut,
   Settings,
@@ -19,6 +20,14 @@ import {
 } from 'lucide-vue-next'
 import { Avatar, AvatarFallback, AvatarImage } from '@/components/ui/avatar'
 import { useAuthStore } from '@/stores/auth'
+import { useLanguage } from '@/composables/useLanguage'
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from '@/components/ui/select'
 import {
   Sidebar,
   SidebarContent,
@@ -41,6 +50,7 @@ import {
 
 const router = useRouter()
 const authStore = useAuthStore()
+const { currentLanguage, currentLanguageLabel, availableLanguages, changeLanguage } = useLanguage()
 
 // Main navigation for all users - computed to allow dynamic URLs
 const navigationItems = computed(() => [
@@ -220,6 +230,26 @@ const handleLogout = () => {
 
     <SidebarFooter>
       <SidebarMenu>
+        <!-- Language Selector -->
+        <SidebarMenuItem>
+          <div class="px-2 py-2">
+            <div class="flex items-center gap-2 mb-2">
+              <Languages class="h-4 w-4" />
+              <span class="text-sm font-medium">Language</span>
+            </div>
+            <Select :model-value="currentLanguage" @update:model-value="changeLanguage">
+              <SelectTrigger class="w-full">
+                <SelectValue>{{ currentLanguageLabel }}</SelectValue>
+              </SelectTrigger>
+              <SelectContent>
+                <SelectItem v-for="lang in availableLanguages" :key="lang.value" :value="lang.value">
+                  {{ lang.label }}
+                </SelectItem>
+              </SelectContent>
+            </Select>
+          </div>
+        </SidebarMenuItem>
+        
         <SidebarMenuItem>
           <!-- Show dropdown when authenticated, otherwise show login link -->
           <DropdownMenu v-if="authStore.isAuthenticated">

--- a/frontend/src/components/AppSidebar.vue
+++ b/frontend/src/components/AppSidebar.vue
@@ -237,7 +237,7 @@ const handleLogout = () => {
               <Languages class="h-4 w-4" />
               <span class="text-sm font-medium">Language</span>
             </div>
-            <Select :model-value="currentLanguage" @update:model-value="(value) => value && changeLanguage(value)">
+            <Select :model-value="currentLanguage" @update:model-value="(value) => typeof value === 'string' && changeLanguage(value)">
               <SelectTrigger class="w-full">
                 <SelectValue>{{ currentLanguageLabel }}</SelectValue>
               </SelectTrigger>

--- a/frontend/src/components/AppSidebar.vue
+++ b/frontend/src/components/AppSidebar.vue
@@ -237,7 +237,7 @@ const handleLogout = () => {
               <Languages class="h-4 w-4" />
               <span class="text-sm font-medium">Language</span>
             </div>
-            <Select :model-value="currentLanguage" @update:model-value="changeLanguage">
+            <Select :model-value="currentLanguage" @update:model-value="(value) => value && changeLanguage(value)">
               <SelectTrigger class="w-full">
                 <SelectValue>{{ currentLanguageLabel }}</SelectValue>
               </SelectTrigger>

--- a/frontend/src/composables/useLanguage.ts
+++ b/frontend/src/composables/useLanguage.ts
@@ -1,0 +1,50 @@
+import { ref, computed } from 'vue'
+import { useI18n } from 'vue-i18n'
+
+const STORAGE_KEY = 'library-language'
+
+export interface LanguageOption {
+  value: string
+  label: string
+}
+
+export const AVAILABLE_LANGUAGES: LanguageOption[] = [
+  { value: 'en', label: 'English' },
+  { value: 'zh-CN', label: '简体中文' }
+]
+
+export function useLanguage() {
+  const { locale } = useI18n()
+  
+  // Initialize language from localStorage or default to 'en'
+  const initializeLanguage = () => {
+    const savedLanguage = localStorage.getItem(STORAGE_KEY)
+    if (savedLanguage && AVAILABLE_LANGUAGES.some(lang => lang.value === savedLanguage)) {
+      locale.value = savedLanguage
+      return savedLanguage
+    }
+    return 'en'
+  }
+
+  const currentLanguage = ref(initializeLanguage())
+
+  const changeLanguage = (newLanguage: string) => {
+    if (AVAILABLE_LANGUAGES.some(lang => lang.value === newLanguage)) {
+      currentLanguage.value = newLanguage
+      locale.value = newLanguage
+      localStorage.setItem(STORAGE_KEY, newLanguage)
+    }
+  }
+
+  const currentLanguageLabel = computed(() => {
+    const lang = AVAILABLE_LANGUAGES.find(lang => lang.value === currentLanguage.value)
+    return lang?.label || 'English'
+  })
+
+  return {
+    currentLanguage,
+    currentLanguageLabel,
+    availableLanguages: AVAILABLE_LANGUAGES,
+    changeLanguage
+  }
+}

--- a/frontend/src/composables/useLanguage.ts
+++ b/frontend/src/composables/useLanguage.ts
@@ -13,20 +13,23 @@ export const AVAILABLE_LANGUAGES: LanguageOption[] = [
   { value: 'zh-CN', label: '简体中文' }
 ]
 
+// Initialize language from localStorage or default to 'en'
+const initializeLanguage = () => {
+  const savedLanguage = localStorage.getItem(STORAGE_KEY)
+  if (savedLanguage && AVAILABLE_LANGUAGES.some(lang => lang.value === savedLanguage)) {
+    return savedLanguage
+  }
+  return 'en'
+}
+
+// Create a singleton reactive ref that's shared across all composable instances
+const currentLanguage = ref(initializeLanguage())
+
 export function useLanguage() {
   const { locale } = useI18n()
   
-  // Initialize language from localStorage or default to 'en'
-  const initializeLanguage = () => {
-    const savedLanguage = localStorage.getItem(STORAGE_KEY)
-    if (savedLanguage && AVAILABLE_LANGUAGES.some(lang => lang.value === savedLanguage)) {
-      locale.value = savedLanguage
-      return savedLanguage
-    }
-    return 'en'
-  }
-
-  const currentLanguage = ref(initializeLanguage())
+  // Sync vue-i18n locale with our current language on initialization
+  locale.value = currentLanguage.value
 
   const changeLanguage = (newLanguage: string) => {
     if (AVAILABLE_LANGUAGES.some(lang => lang.value === newLanguage)) {

--- a/frontend/src/main.ts
+++ b/frontend/src/main.ts
@@ -14,7 +14,12 @@ async function initializeApp() {
   const i18n = createI18n({
     // Disable legacy API mode to use Composition API
     legacy: false,
-    // You can add other i18n options here (locale, messages, etc.)
+    locale: 'en',
+    fallbackLocale: 'en',
+    messages: {
+      en: {},
+      'zh-CN': {}
+    }
   })
 
   app.use(i18n)


### PR DESCRIPTION
A language selector was integrated into the application sidebar.

*   `main.ts` was updated to configure `vue-i18n`, setting `legacy: false` for Composition API compatibility and defining `en` and `zh-CN` as available locales with empty message objects.
*   A new composable, `frontend/src/composables/useLanguage.ts`, was created.
    *   It manages the current language, defaulting to 'en' or a saved preference from `localStorage`.
    *   It exposes `currentLanguage`, `currentLanguageLabel`, `availableLanguages` (`en`, `zh-CN`), and a `changeLanguage` function.
    *   The `changeLanguage` function updates the `vue-i18n` locale and persists the selection to `localStorage`.
*   `frontend/src/components/AppSidebar.vue` was modified to include the language selector.
    *   The `useLanguage` composable was imported and used to access language state and the `changeLanguage` function.
    *   A Shadcn-vue `Select` component was added within a `SidebarMenuItem` in the `SidebarFooter`, positioned above the user button.
    *   The `Select` component binds its value to `currentLanguage` and uses `changeLanguage` for updates, populating options from `availableLanguages`.
    *   A `Languages` icon from `lucide-vue-next` was added for visual indication.

The changes enable language switching with persistence and proper `vue-i18n` integration for future localization.